### PR TITLE
two-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:latest
+# This is a two-stage Docker build:
+# https://docs.docker.com/develop/develop-images/multistage-build/#before-multi-stage-builds
 
-EXPOSE 8080
-
-WORKDIR /go/src/app
+# Build container
+FROM golang:1.10 AS builder
+WORKDIR /go/src/github.com/buchgr/bazel-remote
 COPY . .
+RUN ./linux-build.sh
 
-RUN go-wrapper download
-RUN go-wrapper install
-
-ENTRYPOINT ["go-wrapper", "run", "--port=8080", "--dir=/data"]
+# Runtime container
+FROM alpine:latest
+WORKDIR /root
+EXPOSE 80
+COPY --from=0 /go/src/github.com/buchgr/bazel-remote/bazel-remote .
+ENTRYPOINT ["./bazel-remote", "--port=80", "--dir=/data"]
 CMD ["--max_size=5"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can also run the remote cache by pulling a prebuilt image from [DockerHub](h
 
 ```bash
 $ docker pull buchgr/bazel-remote-cache
-$ docker run -v /path/to/cache/dir:/data -p 9090:8080 buchgr/bazel-remote-cache
+$ docker run -v /path/to/cache/dir:/data -p 9090:80 buchgr/bazel-remote-cache
 ```
 
 Note that you will need to change `/path/to/cache/dir` to a valid directory where the docker container can write to and read from. If you want the docker container to run in the background pass the `-d` flag right after `docker run`.


### PR DESCRIPTION
This removes the go sdk from the final container, making it smaller. I also moved the inner port to 80, which is the default for HTTP. Users can remap it to whatever they want using Docker.

Basically just copy-pasted the Docker docs: https://docs.docker.com/develop/develop-images/multistage-build