### PR TITLE
linux-build.sh should get dependencies

### DIFF
--- a/linux-build.sh
+++ b/linux-build.sh
@@ -2,4 +2,4 @@
 
 # Build static binary
 
-CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
+go get -d ./... && CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
building the docker container fails without go get.

@nicolov 