### PR TITLE
install dependencies in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 # This is a two-stage Docker build:
-# https://docs.docker.com/develop/develop-images/multistage-build/#before-multi-stage-builds
+# https://docs.docker.com/develop/develop-images/multistage-build
 
+#
 # Build container
 FROM golang:1.10 AS builder
+
+# Install dep for vendoring
+ENV GOLANG_DEP_URL https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64
+RUN curl -L -o /usr/local/bin/dep ${GOLANG_DEP_URL} && chmod +x /usr/local/bin/dep
+
 WORKDIR /go/src/github.com/buchgr/bazel-remote
 COPY . .
+RUN dep ensure
 RUN ./linux-build.sh
 
+#
 # Runtime container
 FROM alpine:latest
 WORKDIR /root


### PR DESCRIPTION
I put the `dep` command in the docker file, instead of `linux-build.sh`, since people might want to handle dependencies in their own way? I don't really care a lot either way though.