### PR TITLE
Add logging

### DIFF
--- a/cache/http_test.go
+++ b/cache/http_test.go
@@ -24,7 +24,7 @@ func TestDownloadFile(t *testing.T) {
 	}
 
 	e := NewEnsureSpacer(1, 1)
-	h := NewHTTPCache(cacheDir, 1024, e)
+	h := NewHTTPCache(cacheDir, 1024, e, newSilentLogger())
 
 	req, err := http.NewRequest("GET", "/cas/"+hash, bytes.NewReader([]byte{}))
 	if err != nil {
@@ -75,7 +75,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	}
 
 	e := NewEnsureSpacer(0.8, 0.5)
-	h := NewHTTPCache(cacheDir, 1000*1024, e)
+	h := NewHTTPCache(cacheDir, 1000*1024, e, newSilentLogger())
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -135,7 +135,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	}
 
 	e := NewEnsureSpacer(1, 1)
-	h := NewHTTPCache(cacheDir, 1024, e)
+	h := NewHTTPCache(cacheDir, 1024, e, newSilentLogger())
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -171,7 +171,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	}
 
 	e := NewEnsureSpacer(1, 1)
-	h := NewHTTPCache(cacheDir, 2048, e)
+	h := NewHTTPCache(cacheDir, 2048, e, newSilentLogger())
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -209,7 +209,7 @@ func TestStatusPage(t *testing.T) {
 	}
 
 	e := NewEnsureSpacer(1, 1)
-	h := NewHTTPCache(cacheDir, 2048, e)
+	h := NewHTTPCache(cacheDir, 2048, e, newSilentLogger())
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 	"path/filepath"
+	"log"
 )
 
 func createRandomFile(dir string, size int64) (string, error) {
@@ -33,4 +34,11 @@ func createTmpCacheDirs(t *testing.T) string {
 	ensureDirExists(filepath.Join(path, "cas"))
 
 	return path
+}
+
+// newSilentLogger returns a cheap logger that doesn't print anything, useful
+// for tests.
+func newSilentLogger() (l log.Logger) {
+	l = *log.New(ioutil.Discard, "", 0)
+	return
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	e := cache.NewEnsureSpacer(0.95, 0.5)
 	h := cache.NewHTTPCache(*dir, *maxSize*1024*1024*1024, e)
 
+	http.HandleFunc("/status", maybeAuth(h.StatusPageHandler, *htpasswd_file, *host))
 	http.HandleFunc("/", maybeAuth(h.CacheHandler, *htpasswd_file, *host))
 	var serverErr error
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	auth "github.com/abbot/go-http-auth"
 	"github.com/buchgr/bazel-remote/cache"
+	"os"
 )
 
 func main() {
@@ -29,8 +30,10 @@ func main() {
 		return
 	}
 
+	accessLogger := log.New(os.Stdout, "", log.Ldate | log.Ltime | log.LUTC)
+	errorLogger := log.New(os.Stdout, "", log.Ldate | log.Ltime | log.LUTC)
 	e := cache.NewEnsureSpacer(0.95, 0.5)
-	h := cache.NewHTTPCache(*dir, *maxSize*1024*1024*1024, e)
+	h := cache.NewHTTPCache(*dir, *maxSize*1024*1024*1024, e, *accessLogger, *errorLogger)
 
 	http.HandleFunc("/status", maybeAuth(h.StatusPageHandler, *htpasswd_file, *host))
 	http.HandleFunc("/", maybeAuth(h.CacheHandler, *htpasswd_file, *host))


### PR DESCRIPTION
Very basic logging, with one logger for responses and one for errors (like most HTTP servers). The loggers are injected into the `httpCache` instance. I don't like using those middlewares that hijack the response, so I've just added explicit function calls to the logging points. I don't feel that strongly about it, however.

Please review this after the status page PR, as those changes are included here too.