### PR TITLE
Put back Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# This is a two-stage Docker build:
+# https://docs.docker.com/develop/develop-images/multistage-build
+
+#
+# Build container
+FROM golang:1.10 AS builder
+
+# Install dep for vendoring
+ENV GOLANG_DEP_URL https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64
+RUN curl -L -o /usr/local/bin/dep ${GOLANG_DEP_URL} && chmod +x /usr/local/bin/dep
+
+WORKDIR /go/src/github.com/buchgr/bazel-remote
+COPY . .
+RUN dep ensure
+RUN ./linux-build.sh
+
+#
+# Runtime container
+FROM alpine:latest
+WORKDIR /root
+EXPOSE 80
+COPY --from=0 /go/src/github.com/buchgr/bazel-remote/bazel-remote .
+ENTRYPOINT ["./bazel-remote", "--port=80", "--dir=/data"]

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .


### PR DESCRIPTION
My infra team asked for a standard Dockerfile, so that they can use the same workflow that they use for deploying other services. I believe it will also be useful to other people, so we should put it back.