### PR TITLE
Allow overwriting existing items

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -129,14 +129,16 @@ func (c *fsCache) loadExistingFiles() {
 func (c *fsCache) Put(key string, size int64, expectedSha256 string, r io.Reader) (err error) {
 	c.mux.Lock()
 
-	// If `key` is already in the LRU, don't touch the cache and just discard
-	// the incoming stream. This applies to both committed an uncommitted files
-	// (we don't want to upload again if an upload of the same file is already
-	// in progress).
-	if _, found := c.lru.Get(key); found {
-		c.mux.Unlock()
-		io.Copy(ioutil.Discard, r)
-		return
+	// If there's an ongoing upload (i.e. cache key is present in uncommitted state),
+	// we drop the upload and discard the incoming stream. We do accept uploads
+	// of existing keys, as it should happen relatively rarely (e.g. race
+	// condition on the bazel side) but it's useful to overwrite poisoned items.
+	if existingItem, found := c.lru.Get(key); found {
+		if !existingItem.(*lruItem).committed {
+			c.mux.Unlock()
+			io.Copy(ioutil.Discard, r)
+			return
+		}
 	}
 
 	// Try to add the item to the LRU.


### PR DESCRIPTION
While this is not useful in normal conditions (since bazel will GET before trying a PUT, and the window for race conditions is pretty small), overwriting is useful to discard poisoned cache items. By using `bazel build --remote_accept_cached=false`, bazel will rebuild everything locally and upload the results to the cache, healing any corrupted/poisoned items.