### PR TITLE
Print git version in status page

### DIFF
--- a/cache/http.go
+++ b/cache/http.go
@@ -34,11 +34,15 @@ type httpCache struct {
 }
 
 type statusPageData struct {
-	CurrSize   int64
-	MaxSize    int64
-	NumFiles   int
-	ServerTime int64
+	CurrSize      int64
+	MaxSize       int64
+	NumFiles      int
+	ServerTime    int64
+	ServerVersion string
 }
+
+// Version stamp for the server. The value of this var is set through linker options.
+var ServerVersion string
 
 // NewHTTPCache returns a new instance of the cache.
 // accessLogger will print one line for each HTTP request to the cache.
@@ -174,9 +178,10 @@ func (h *httpCache) StatusPageHandler(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", " ")
 	enc.Encode(statusPageData{
-		CurrSize:   h.cache.CurrentSize(),
-		MaxSize:    h.cache.MaxSize(),
-		NumFiles:   h.cache.NumItems(),
-		ServerTime: time.Now().Unix(),
+		CurrSize:      h.cache.CurrentSize(),
+		MaxSize:       h.cache.MaxSize(),
+		NumFiles:      h.cache.NumItems(),
+		ServerTime:    time.Now().Unix(),
+		ServerVersion: ServerVersion,
 	})
 }

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -2,4 +2,7 @@
 
 set -euxo pipefail
 
-CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
+VERSION_TAG="$(git describe --always --dirty)"
+VERSION_LINK_FLAG="github.com/buchgr/bazel-remote/cache.ServerVersion=${VERSION_TAG}"
+
+CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-extldflags '-static' -X ${VERSION_LINK_FLAG}" .


### PR DESCRIPTION
Use the `-X` flag to the linker to embed git version information in the server binary, and print this information in the status page:

```
{
 "CurrSize": 0,
 "MaxSize": 10737418240,
 "NumFiles": 0,
 "ServerTime": 1528156621,
 "ServerVersion": "a701b69-dirty"
}
```