### PR TITLE
Allow configuration via environment variables

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//cache:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",
+        "@com_github_urfave_cli//:go_default_library",
     ],
 )
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,6 +14,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/urfave/cli"
+  packages = ["."]
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,6 +6,10 @@
   name = "github.com/djherbis/atime"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/urfave/cli"
+  version = "1.20.0"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,12 @@ go_repository(
 )
 
 go_repository(
+    name = "com_github_urfave_cli",
+    commit = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1",
+    importpath = "github.com/urfave/cli",
+)
+
+go_repository(
     name = "com_github_djherbis_atime",
     commit = "8e47e0e01d08df8b9f840d74299c8ab70a024a30",
     importpath = "github.com/djherbis/atime",


### PR DESCRIPTION
This follows the tenets of the [12 factor app](https://12factor.net/config), making configuration of the `bazel-remote` docker image much easier to manage.