### PR TITLE
Add s3 as a cache backend 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,10 +14,11 @@ go_library(
     importpath = "github.com/buchgr/bazel-remote",
     visibility = ["//visibility:private"],
     deps = [
-        "//cache:go_default_library",
         "//cache/disk:go_default_library",
         "//cache/gcs:go_default_library",
         "//cache/http:go_default_library",
+        "//cache/s3:go_default_library",
+        "//cache:go_default_library",
         "//config:go_default_library",
         "//server:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,15 @@
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz",
-    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.1/rules_go-0.16.1.tar.gz",
+    sha256 = "f5127a8f911468cd0b2d7a141f17253db81177523e4429796e14d429f5444f5f",
 )
+
+
 
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz",
-    sha256 = "ddedc7aaeb61f2654d7d7d4fd7940052ea992ccdb031b8f9797ed143ac7e8d43",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz",
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
 )
 
 git_repository(
@@ -23,7 +25,11 @@ load(
 
 _go_image_repos()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_register_toolchains",
+    "go_rules_dependencies",
+)
 
 go_rules_dependencies()
 
@@ -50,6 +56,40 @@ go_repository(
     name = "com_github_djherbis_atime",
     commit = "8e47e0e01d08df8b9f840d74299c8ab70a024a30",
     importpath = "github.com/djherbis/atime",
+)
+
+go_repository(
+    # minio has this dependency
+    name = "com_github_go_ini_ini",
+    importpath="github.com/go-ini/ini",
+    commit="9c8236e659b76e87bf02044d06fde8683008ff3e",
+)
+
+go_repository(
+    # minio has this dependency
+    name = "org_golang_x_net",
+    commit = "c39426892332e1bb5ec0a434a079bf82f5d30c54",
+    importpath = "golang_org/x/net",
+)
+
+go_repository(
+    # minio has this dependency
+    name = "org_golang_x_sys",
+    commit = "d69651ed3497faee15a5363a89578e9991f6d5e2",
+    importpath = "golang.org/x/sys",
+)
+
+go_repository(
+    # minio has this dependency
+    name = "com_github_mitchellh_go_homedir",
+    commit = "ae18d6b8b3205b561c79e8e5f69bff09736185f4",
+    importpath = "github.com/mitchellh/go-homedir",
+)
+
+go_repository(
+    name = "com_github_minio_go",
+    commit = "55c9b2e90ef38c5962d872ebc34b5d7c0e04974c",
+    importpath = "github.com/minio/minio-go",
 )
 
 go_repository(

--- a/cache/s3/BUILD.bazel
+++ b/cache/s3/BUILD.bazel
@@ -7,17 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",
+        "//config:go_default_library",
         "@com_github_minio_go//:go_default_library"
     ],
 )
 
-go_test(
-    name = "go_default_test",
-    srcs = ["s3_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//cache:go_default_library",
-        "//cache/disk:go_default_library",
-        "//utils:go_default_library",
-    ],
-)

--- a/cache/s3/BUILD.bazel
+++ b/cache/s3/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["s3.go"],
+    importpath = "github.com/buchgr/bazel-remote/cache/s3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cache:go_default_library",
+        "@com_github_minio_go//:go_default_library"
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["s3_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//cache:go_default_library",
+        "//cache/disk:go_default_library",
+        "//utils:go_default_library",
+    ],
+)

--- a/cache/s3/s3.go
+++ b/cache/s3/s3.go
@@ -61,8 +61,22 @@ func (c *s3Cache) Put(key string, size int64, expectedSha256 string, r io.Reader
 // Get writes the content of the cache item stored under `key` to `w`. If the item is
 // not found, it returns ok = false.
 func (c *s3Cache) Get(key string, actionCache bool) (data io.ReadCloser, sizeBytes int64, err error) {
+	objInfo, err := c.mclient.StatObject(
+		c.bucket, // bucketName
+		key,      // objectName
+		minio.StatObjectOptions{}, // opts
+	)
+	if err != nil {
+		return nil, 0, err
+	}
 
-	return nil, 0, nil
+	object, err := c.mclient.GetObject(
+		c.bucket, // bucketName
+		key,      // objectName
+		minio.GetObjectOptions{}, // opts
+	)
+
+	return object, objInfo.Size, err
 }
 
 // Contains returns true if the `key` exists.

--- a/cache/s3/s3.go
+++ b/cache/s3/s3.go
@@ -1,10 +1,11 @@
 package s3
 
 import (
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/minio/minio-go"
 	"io"
 	"log"
+
+	"github.com/buchgr/bazel-remote/cache"
+	"github.com/minio/minio-go"
 )
 
 type s3Cache struct {
@@ -81,24 +82,32 @@ func (c *s3Cache) Get(key string, actionCache bool) (data io.ReadCloser, sizeByt
 
 // Contains returns true if the `key` exists.
 func (c *s3Cache) Contains(key string, actionCache bool) (ok bool) {
-
-	return true
+	objInfo, err := c.mclient.StatObject(
+		c.bucket, // bucketName
+		key,      // objectName
+		minio.StatObjectOptions{}, // opts
+	)
+	if err == nil {
+		return true
+	}
+	return false
 }
 
 // MaxSize returns the maximum cache size in bytes.
 func (c *s3Cache) MaxSize() int64 {
-
-	return 0
+	// In order to return the max size, we will need to iterate over all the
+	// objects in a bucket via s3. Each object will be an API call.
+	// Since this can take a long time, and there are other ways (see AWS/Minio
+	// dashboards) to get the same information, these are not implemented.
+	return -1
 }
 
 // CurrentSize returns the current cache size in bytes.
 func (c *s3Cache) CurrentSize() int64 {
-
-	return 0
+	return -1
 }
 
 // NumItems returns the number of items stored in the cache.
 func (c *s3Cache) NumItems() int {
-
-	return 0
+	return -1
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type S3CloudStorageConfig struct {
+	Endpoint        string `yaml:"endpoint"`
 	Bucket          string `yaml:"bucket"`
 	Location        string `yaml:"location"`
 	AccessKeyID     string `yaml:"access_key_id"`

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,13 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type S3CloudStorageConfig struct {
+	Bucket          string `yaml:"bucket"`
+	Location        string `yaml:"location"`
+	AccessKeyID     string `yaml:"access_key_id"`
+	SecretAccessKey string `yaml:"secret_access_key"`
+}
+
 type GoogleCloudStorageConfig struct {
 	Bucket                string `yaml:"bucket"`
 	UseDefaultCredentials bool   `yaml:"use_default_credentials"`
@@ -28,6 +35,7 @@ type Config struct {
 	HtpasswdFile       string                    `yaml:"htpasswd_file"`
 	TLSCertFile        string                    `yaml:"tls_cert_file"`
 	TLSKeyFile         string                    `yaml:"tls_key_file"`
+	S3CloudStorage     *S3CloudStorageConfig     `yaml:"s3_proxy"`
 	GoogleCloudStorage *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
 	HTTPBackend        *HTTPBackendConfig        `yaml:"http_proxy"`
 }
@@ -98,7 +106,7 @@ func validateConfig(c *Config) error {
 			"'tls_key_file' and 'tls_cert_file'")
 	}
 
-	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil {
+	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil && c.S3CloudStorage != nil {
 		return errors.New("One can specify at most one proxying backend")
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -96,3 +96,37 @@ http_proxy:
 		t.Fatalf("Expected '%+v' but got '%+v'", expectedConfig, config)
 	}
 }
+
+func TestValidS3CloudStorageConfig(t *testing.T) {
+	yaml := `host: localhost
+port: 8080
+dir: /opt/cache-dir
+max_size: 100
+s3_proxy:
+  bucket: test-bucket
+  location: test-location
+  access_key_id: EXAMPLE_ACCESS_KEY
+  secret_access_key: EXAMPLE_SECRET_KEY
+`
+	config, err := newFromYaml([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedConfig := &Config{
+		Host:    "localhost",
+		Port:    8080,
+		Dir:     "/opt/cache-dir",
+		MaxSize: 100,
+		S3CloudStorage: &S3CloudStorageConfig{
+			Bucket:          "test-bucket",
+			Location:        "test-location",
+			AccessKeyID:     "EXAMPLE_ACCESS_KEY",
+			SecretAccessKey: "EXAMPLE_SECRET_KEY",
+		},
+	}
+
+	if !cmp.Equal(config, expectedConfig) {
+		t.Fatalf("Expected '%+v' but got '%+v'", expectedConfig, config)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,7 @@ port: 8080
 dir: /opt/cache-dir
 max_size: 100
 s3_proxy:
+  endpoint: minio.example.com:9000
   bucket: test-bucket
   location: test-location
   access_key_id: EXAMPLE_ACCESS_KEY
@@ -119,6 +120,7 @@ s3_proxy:
 		Dir:     "/opt/cache-dir",
 		MaxSize: 100,
 		S3CloudStorage: &S3CloudStorageConfig{
+			Endpoint:        "minio.example.com:9000",
 			Bucket:          "test-bucket",
 			Location:        "test-location",
 			AccessKeyID:     "EXAMPLE_ACCESS_KEY",

--- a/main.go
+++ b/main.go
@@ -128,9 +128,7 @@ func main() {
 			proxyCache = cachehttp.New(baseURL, diskCache,
 				httpClient, accessLogger, errorLogger)
 		} else if c.S3CloudStorage != nil {
-			proxyCache = s3.New(c.S3CloudStorage.Endpoint, c.S3CloudStorage.Bucket,
-				c.S3CloudStorage.Location, c.S3CloudStorage.AccessKeyID,
-				c.S3CloudStorage.SecretAccessKey)
+			proxyCache = s3.New(c.S3CloudStorage)
 		} else {
 			proxyCache = diskCache
 		}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buchgr/bazel-remote/cache"
 	"github.com/buchgr/bazel-remote/cache/disk"
 	"github.com/buchgr/bazel-remote/cache/gcs"
+	"github.com/buchgr/bazel-remote/cache/s3"
 
 	cachehttp "github.com/buchgr/bazel-remote/cache/http"
 
@@ -126,6 +127,10 @@ func main() {
 			}
 			proxyCache = cachehttp.New(baseURL, diskCache,
 				httpClient, accessLogger, errorLogger)
+		} else if c.S3CloudStorage != nil {
+			proxyCache = s3.New(c.S3CloudStorage.Endpoint, c.S3CloudStorage.Bucket,
+				c.S3CloudStorage.Location, c.S3CloudStorage.AccessKeyID,
+				c.S3CloudStorage.SecretAccessKey)
 		} else {
 			proxyCache = diskCache
 		}


### PR DESCRIPTION
This change adds a new cache back-end to the project.

In order to add the new back-end, I have added a dependency to the minio go-sdk. I also had to update the versions of rules_go and gazelle that we point to. Let me know if you'd like to see that as a separate pull-request, and I'll be happy to split it.

I also have a simple unittest for the configuration check. I couldn't think of an easy way to unittest the s3 functionality (since it's just calling s3 APIs), see some functional tests I ran locally below.

This is my first PR against this project, let me know if you need me to change something, I'll be happy to do it.

----
Functional testing done:

Started minio via docker:

```
$ docker run -p 9000:9000 --name minio1                           \
  -v /home/sbharadwaj/local/bazel-data:/data                      \
  -v /home/sbharadwaj/.minio:/root/.minio                         \
   minio/minio server /data
```

Then run the bazel-remote project like so:

```
❯ bazel run :bazel-remote -- --config_file test.yaml 
```

where the `test.yaml` file is:
```
host: localhost
dir: /home/sbharadwaj/local/data
port: 8080
max_size: 100
s3_proxy:
  endpoint: '127.0.0.1:9000'
  bucket: test-bucket
  location: test-location
  access_key_id: <KEY_ID>
  secret_access_key: <SEC_KEY>
```

To test, I try to upload a simple file:

```
    $ sha256sum README.md | \
      cut -f1 -d' '       | \
      xargs -I% curl --upload-file README.md http://localhost:8080/cas/%
```

Then download using:
```
    $ sha256sum README.md | \
      cut -f1 -d' '       | \
      xargs -I% curl http://localhost:8080/cas/%
```
Resolves: buchgr#56