### PR TITLE
running gcc failed: exec: "gcc": executable file not found in $PATH

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,8 +6,8 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz",
-    sha256 = "ddedc7aaeb61f2654d7d7d4fd7940052ea992ccdb031b8f9797ed143ac7e8d43",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz",
+    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
 )
 
 git_repository(


### PR DESCRIPTION
When I compile from source on Ubuntu 18.04 ppc64le I saw this error:
'running gcc failed: exec: "gcc": executable file not found in $PATH when compiling'
I found a PR already fixed it in this PR: https://github.com/bazelbuild/bazel-gazelle/pull/241, so updating bazel_gazelle fixed my problem.