### PR TITLE
disk.go: Don't sync after writing a file.

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -220,10 +220,6 @@ func (c *diskCache) Put(kind cache.EntryKind, hash string, size int64, r io.Read
 		}
 	}
 
-	if err := f.Sync(); err != nil {
-		return err
-	}
-
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
The sync protects against data loss in case the power goes out suddenly, but I don't think that level of protection is needed for a cache server - in the worst case, if it loses a file, the clients can regenerate it anyway.