### PR TITLE
Add max_idle_time flag to exit bazel-remote when idling for certain time

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,12 +3,14 @@ package cache
 import (
 	"io"
 	"time"
+	"sync"
 )
 
 // EntryKind describes the kind of cache entry
 type EntryKind int
 
 var LastRequestTime time.Time
+var CacheMutex = &sync.Mutex{}
 
 const (
 	// AC stands for Action Cache

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,10 +2,13 @@ package cache
 
 import (
 	"io"
+	"time"
 )
 
 // EntryKind describes the kind of cache entry
 type EntryKind int
+
+var LastRequestTime time.Time
 
 const (
 	// AC stands for Action Cache

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/buchgr/bazel-remote/cache"
 	"github.com/djherbis/atime"
@@ -146,6 +147,7 @@ func (c *diskCache) loadExistingFiles() error {
 }
 
 func (c *diskCache) Put(kind cache.EntryKind, hash string, size int64, r io.Reader) (err error) {
+	cache.LastRequestTime = time.Now()
 	c.mux.Lock()
 
 	key := cacheKey(kind, hash)
@@ -241,6 +243,7 @@ func (c *diskCache) Put(kind cache.EntryKind, hash string, size int64, r io.Read
 }
 
 func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, sizeBytes int64, err error) {
+	cache.LastRequestTime = time.Now()
 	if !c.Contains(kind, hash) {
 		return
 	}
@@ -262,6 +265,7 @@ func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, 
 }
 
 func (c *diskCache) Contains(kind cache.EntryKind, hash string) (ok bool) {
+	cache.LastRequestTime = time.Now()
 	c.mux.Lock()
 	defer c.mux.Unlock()
 

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -147,9 +147,11 @@ func (c *diskCache) loadExistingFiles() error {
 }
 
 func (c *diskCache) Put(kind cache.EntryKind, hash string, size int64, r io.Reader) (err error) {
+	cache.CacheMutex.Lock()
 	cache.LastRequestTime = time.Now()
-	c.mux.Lock()
+	cache.CacheMutex.Unlock()
 
+	c.mux.Lock()
 	key := cacheKey(kind, hash)
 
 	// If there's an ongoing upload (i.e. cache key is present in uncommitted state),
@@ -243,7 +245,6 @@ func (c *diskCache) Put(kind cache.EntryKind, hash string, size int64, r io.Read
 }
 
 func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, sizeBytes int64, err error) {
-	cache.LastRequestTime = time.Now()
 	if !c.Contains(kind, hash) {
 		return
 	}
@@ -265,7 +266,9 @@ func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, 
 }
 
 func (c *diskCache) Contains(kind cache.EntryKind, hash string) (ok bool) {
+	cache.CacheMutex.Lock()
 	cache.LastRequestTime = time.Now()
+	cache.CacheMutex.Unlock()
 	c.mux.Lock()
 	defer c.mux.Unlock()
 

--- a/cache/http/http.go
+++ b/cache/http/http.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/buchgr/bazel-remote/cache"
 )
@@ -34,7 +33,6 @@ type remoteHTTPProxyCache struct {
 
 func uploadFile(remote *http.Client, baseURL *url.URL, local cache.Cache, accessLogger cache.Logger,
 	errorLogger cache.Logger, hash string, kind cache.EntryKind) {
-	cache.LastRequestTime = time.Now()
 	data, size, err := local.Get(kind, hash)
 	if err != nil {
 		return

--- a/cache/http/http.go
+++ b/cache/http/http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/buchgr/bazel-remote/cache"
 )
@@ -33,6 +34,7 @@ type remoteHTTPProxyCache struct {
 
 func uploadFile(remote *http.Client, baseURL *url.URL, local cache.Cache, accessLogger cache.Logger,
 	errorLogger cache.Logger, hash string, kind cache.EntryKind) {
+	cache.LastRequestTime = time.Now()
 	data, size, err := local.Get(kind, hash)
 	if err != nil {
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	TLSKeyFile         string                    `yaml:"tls_key_file"`
 	GoogleCloudStorage *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
 	HTTPBackend        *HTTPBackendConfig        `yaml:"http_proxy"`
+	IdleTimeout        int64                     `yaml:"idle_timeout"`
 }
 
 // New ...
@@ -40,6 +41,7 @@ func New(dir string, maxSize int, host string, port int, htpasswdFile string,
 		Port:               port,
 		Dir:                dir,
 		MaxSize:            maxSize,
+		IdleTimeout:        0,
 		HtpasswdFile:       htpasswdFile,
 		TLSCertFile:        tlsCertFile,
 		TLSKeyFile:         tlsKeyFile,

--- a/main.go
+++ b/main.go
@@ -145,14 +145,18 @@ func main() {
 		httpServer := &http.Server{Addr: c.Host+":"+strconv.Itoa(c.Port), Handler: nil}
 
 		if c.IdleTimeout > 0 {
+			cache.CacheMutex.Lock()
 			cache.LastRequestTime = time.Now()
+			cache.CacheMutex.Unlock()
 			ticker := time.NewTicker(time.Second)
 			go func() {
 				for {
 					select {
 					case <-ticker.C:
 						currentTime := time.Now()
+						cache.CacheMutex.Lock()
 						lastRequestTime := cache.LastRequestTime
+						cache.CacheMutex.Unlock()
 						if int64(currentTime.Sub(lastRequestTime).Seconds()) > c.IdleTimeout {
 							accessLogger.Printf("Shutting down server after idling for more than %d seconds", c.IdleTimeout)
 							httpServer.Shutdown(context.Background())


### PR DESCRIPTION
This is for https://github.com/buchgr/bazel-remote/issues/61.
The max_idle_time flag is useful when using bazel-remote as a local proxy to PUT cache objects to remote cache server and exit when idle for a time specified by max_idle_time flag. This allows for local build finish early and leave bazel-remote to finish the PUT request queue, instead of waiting for the PUT requests to finish.