### PR TITLE
Create a pid file under bazel-remote cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ GLOBAL OPTIONS:
    --tls_cert_file value  Path to a pem encoded certificate file. [$BAZEL_REMOTE_TLS_CERT_FILE]
    --tls_key_file value   Path to a pem encoded key file. [$BAZEL_REMOTE_TLS_KEY_FILE]
    --idle_timeout value   The maximum period of having received no request after which the server will shut itself down. Disabled by default. (default: 0s) [$BAZEL_REMOTE_IDLE_TIMEOUT]
+   --kill_old_pid value   This will kill the existing running bazel-remote process before starting a new bazel-remote process. This is when user want to upgrade with a new version
    --help, -h             show help
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,11 +32,12 @@ type Config struct {
 	GoogleCloudStorage *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
 	HTTPBackend        *HTTPBackendConfig        `yaml:"http_proxy"`
 	IdleTimeout        time.Duration             `yaml:"idle_timeout"`
+	KillOldPid         bool                      `yaml:"kill_old_pid"`
 }
 
 // New ...
 func New(dir string, maxSize int, host string, port int, htpasswdFile string,
-	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration) (*Config, error) {
+	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration, killOldPid bool) (*Config, error) {
 	c := Config{
 		Host:               host,
 		Port:               port,
@@ -48,6 +49,7 @@ func New(dir string, maxSize int, host string, port int, htpasswdFile string,
 		GoogleCloudStorage: nil,
 		HTTPBackend:        nil,
 		IdleTimeout:        idleTimeout,
+		KillOldPid:         killOldPid,
 	}
 
 	err := validateConfig(&c)


### PR DESCRIPTION
This is for managing local bazel-remote processes. With pid files under the cache folder, bazel-remote can check previous invocations of bazel-remote and take corresponding action according to either flag or config file specification. 
For CI box, when there is a new build job, bazel-remote can check if there is already a previous bazel-remote process running, and if yes, it can either select to kill all previous invocations to use a new version of bazel-remote; or select to just select to continue to use previous invocations.
For dev box, when user run bazel build, it can spawn bazel-remote process with the same options as CI box.