### PR TITLE
Change default mode for dirs from 0744 to 0777 and files from 0600 to 0666

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -43,11 +43,11 @@ func New(dir string, maxSizeBytes int64) cache.Cache {
 	for _, c1 := range hexLetters {
 		for _, c2 := range hexLetters {
 			subDir := string(c1) + string(c2)
-			err := os.MkdirAll(filepath.Join(dir, cache.CAS.String(), subDir), os.FileMode(0744))
+			err := os.MkdirAll(filepath.Join(dir, cache.CAS.String(), subDir), os.FileMode(0755))
 			if err != nil {
 				log.Fatal(err)
 			}
-			err = os.MkdirAll(filepath.Join(dir, cache.AC.String(), subDir), os.FileMode(0744))
+			err = os.MkdirAll(filepath.Join(dir, cache.AC.String(), subDir), os.FileMode(0755))
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -290,7 +290,7 @@ func (c *diskCache) CurrentSize() int64 {
 
 func ensureDirExists(path string) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		err = os.MkdirAll(path, os.FileMode(0744))
+		err = os.MkdirAll(path, os.FileMode(0755))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -20,19 +20,19 @@ func TempDir(t *testing.T) string {
 
 func CreateRandomFile(dir string, size int64) (string, error) {
 	data, hash := RandomDataAndHash(size)
-	os.MkdirAll(dir, os.FileMode(0744))
+	os.MkdirAll(dir, os.FileMode(0755))
 	filepath := dir + "/" + hash
 
-	return hash, ioutil.WriteFile(filepath, data, 0744)
+	return hash, ioutil.WriteFile(filepath, data, 0644)
 }
 
 func CreateCacheFile(dir string, size int64) (string, error) {
 	data, hash := RandomDataAndHash(size)
 	subdir := dir + "/" + hash[0:2]
-	os.MkdirAll(subdir, os.FileMode(0744))
+	os.MkdirAll(subdir, os.FileMode(0755))
 	filepath := subdir + "/" + hash
 
-	return hash, ioutil.WriteFile(filepath, data, 0744)
+	return hash, ioutil.WriteFile(filepath, data, 0644)
 }
 
 func RandomDataAndHash(size int64) ([]byte, string) {
@@ -48,7 +48,7 @@ func CreateTmpCacheDirs(t *testing.T) string {
 	if err != nil {
 		t.Error("Couldn't create tmp dir", err)
 	}
-	os.MkdirAll(path, os.FileMode(0744))
+	os.MkdirAll(path, os.FileMode(0755))
 	return path
 }
 

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -20,7 +20,7 @@ func TempDir(t *testing.T) string {
 
 func CreateRandomFile(dir string, size int64) (string, error) {
 	data, hash := RandomDataAndHash(size)
-	os.MkdirAll(dir, os.FileMode(0755))
+	os.MkdirAll(dir, os.FileMode(0777))
 	filepath := dir + "/" + hash
 
 	return hash, ioutil.WriteFile(filepath, data, 0644)
@@ -29,7 +29,7 @@ func CreateRandomFile(dir string, size int64) (string, error) {
 func CreateCacheFile(dir string, size int64) (string, error) {
 	data, hash := RandomDataAndHash(size)
 	subdir := dir + "/" + hash[0:2]
-	os.MkdirAll(subdir, os.FileMode(0755))
+	os.MkdirAll(subdir, os.FileMode(0777))
 	filepath := subdir + "/" + hash
 
 	return hash, ioutil.WriteFile(filepath, data, 0644)
@@ -48,7 +48,7 @@ func CreateTmpCacheDirs(t *testing.T) string {
 	if err != nil {
 		t.Error("Couldn't create tmp dir", err)
 	}
-	os.MkdirAll(path, os.FileMode(0755))
+	os.MkdirAll(path, os.FileMode(0777))
 	return path
 }
 


### PR DESCRIPTION
This makes it easier to administer the cache directory when
bazel-remote is not running as the same user as the server admin (and
the server admin doesn't have root).

Note that ioutil.MkdirAll() respects umask so if you still want 0744,
you can just set your umask to 0033.

Fixes issue #78 