### PR TITLE
Explicitly specify goarch and goos to build the binary for Linux

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,8 @@ go_image(
     embed = [":go_default_library"],
     pure = "on",
     static = "on",
+    goarch = "amd64",
+    goos = "linux",
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
Since the container (distroless go container) on which the binary
runs is Linux, the binary needs to be built for Linux.
Without this, on MacOSX, the binary is built for darwin and thus
fails to run in the Linux container.