### PR TITLE
Fix misleading internal server error

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -107,7 +107,11 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		data, sizeBytes, err := h.cache.Get(kind, hash)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			if e, ok := err.(*cache.Error); ok {
+				http.Error(w, e.Error(), e.Code)
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 			h.errorLogger.Printf("GET %s: %s", path(kind, hash), err)
 			return
 		}


### PR DESCRIPTION
If the http_proxy returned 404, bazel-remote was returning 500.

The test is a bit convoluted... I'm open to ideas on how to make it simpler. 

Fixes #84 