### PR TITLE
Allow cross-platform Docker builds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,6 +39,8 @@ go_image(
     embed = [":go_default_library"],
     pure = "on",
     static = "on",
+    goos = "linux",
+    goarch = "amd64",
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
This PR explicitly sets `GOOS` and `GOARCH` to `linux/amd64` when creating the docker image.  This enables developers on a non-Linux platform to produce functional docker images instead of inadvertently embedding a binary built for their local architecture into the image.