### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,10 +1,5 @@
 ---
 platforms:
-  ubuntu1404:
-    build_targets:
-    - "..."
-    test_targets:
-    - "..."
   ubuntu1604:
     build_targets:
     - "..."


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ