### PR TITLE
fix the cache interface documentation

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -42,15 +42,17 @@ func (e *Error) Error() string {
 // locking internally.
 type Cache interface {
 
-	// Put stores a stream of `size` bytes from `r` into the cache. If `expectedSha256` is
-	// not the empty string, and the contents don't match it, an error is returned
+	// Put stores a stream of `size` bytes from `r` into the cache. If `hash` is
+	// not the empty string, and the contents don't match it, a non-nil error is
+	// returned.
 	Put(kind EntryKind, hash string, size int64, r io.Reader) error
 
-	// Get writes the content of the cache item stored under `key` to `w`. If the item is
-	// not found, it returns ok = false.
-	Get(kind EntryKind, hash string) (data io.ReadCloser, sizeBytes int64, err error)
+	// Get returns an io.ReadCloser with the content of the cache item stored under `hash`
+	// and the number of bytes that can be read from it. If the item is not found, `r` is
+	// nil. If some error occurred when processing the request, then it is returned.
+	Get(kind EntryKind, hash string) (r io.ReadCloser, sizeBytes int64, err error)
 
-	// Contains returns true if the `key` exists.
+	// Contains returns true if the `hash` key exists in the cache.
 	Contains(kind EntryKind, hash string) (ok bool)
 
 	// MaxSize returns the maximum cache size in bytes.


### PR DESCRIPTION
The previous comments were out of date, and refer to variables that
have since been renamed, and to older return types.