### PR TITLE
rdr is a better variable name than data for cache.Get / cache.Put

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -42,15 +42,15 @@ func (e *Error) Error() string {
 // locking internally.
 type Cache interface {
 
-	// Put stores a stream of `size` bytes from `r` into the cache. If `hash` is
+	// Put stores a stream of `size` bytes from `rdr` into the cache. If `hash` is
 	// not the empty string, and the contents don't match it, a non-nil error is
 	// returned.
-	Put(kind EntryKind, hash string, size int64, r io.Reader) error
+	Put(kind EntryKind, hash string, size int64, rdr io.Reader) error
 
 	// Get returns an io.ReadCloser with the content of the cache item stored under `hash`
-	// and the number of bytes that can be read from it. If the item is not found, `r` is
+	// and the number of bytes that can be read from it. If the item is not found, `rdr` is
 	// nil. If some error occurred when processing the request, then it is returned.
-	Get(kind EntryKind, hash string) (r io.ReadCloser, sizeBytes int64, err error)
+	Get(kind EntryKind, hash string) (rdr io.ReadCloser, sizeBytes int64, err error)
 
 	// Contains returns true if the `hash` key exists in the cache.
 	Contains(kind EntryKind, hash string) (ok bool)

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -249,7 +249,7 @@ func (c *diskCache) Put(kind cache.EntryKind, hash string, expectedSize int64, r
 	return
 }
 
-func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, sizeBytes int64, err error) {
+func (c *diskCache) Get(kind cache.EntryKind, hash string) (rdr io.ReadCloser, sizeBytes int64, err error) {
 	if !c.Contains(kind, hash) {
 		return
 	}
@@ -262,7 +262,7 @@ func (c *diskCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, 
 	}
 	sizeBytes = fileInfo.Size()
 
-	data, err = os.Open(blobPath)
+	rdr, err = os.Open(blobPath)
 	if err != nil {
 		return
 	}

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -72,11 +72,11 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Non-existing item
-	data, sizeBytes, err := testCache.Get(cache.CAS, CONTENTS_HASH)
+	rdr, sizeBytes, err := testCache.Get(cache.CAS, CONTENTS_HASH)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if data != nil {
+	if rdr != nil {
 		t.Fatal("expected the item not to exist")
 	}
 
@@ -94,12 +94,12 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Get the item back
-	data, sizeBytes, err = testCache.Get(cache.CAS, CONTENTS_HASH)
+	rdr, sizeBytes, err = testCache.Get(cache.CAS, CONTENTS_HASH)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = expectContentEquals(data, sizeBytes, []byte(CONTENTS))
+	err = expectContentEquals(rdr, sizeBytes, []byte(CONTENTS))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,21 +149,21 @@ func TestCachePutWrongSize(t *testing.T) {
 	}
 }
 
-func expectContentEquals(data io.ReadCloser, sizeBytes int64, expectedContent []byte) error {
-	if data == nil {
+func expectContentEquals(rdr io.ReadCloser, sizeBytes int64, expectedContent []byte) error {
+	if rdr == nil {
 		return fmt.Errorf("expected the item to exist")
 	}
-	dataBytes, err := ioutil.ReadAll(data)
+	data, err := ioutil.ReadAll(rdr)
 	if err != nil {
 		return err
 	}
-	if bytes.Compare(dataBytes, expectedContent) != 0 {
+	if bytes.Compare(data, expectedContent) != 0 {
 		return fmt.Errorf("expected response '%s', but received '%s'",
-			expectedContent, dataBytes)
+			expectedContent, data)
 	}
-	if int64(len(dataBytes)) != sizeBytes {
+	if int64(len(data)) != sizeBytes {
 		return fmt.Errorf("Expected sizeBytes to be '%d' but was '%d'",
-			sizeBytes, len(dataBytes))
+			sizeBytes, len(data))
 	}
 
 	return nil
@@ -175,12 +175,12 @@ func putGetCompare(kind cache.EntryKind, hash string, content string, testCache 
 		return err
 	}
 
-	data, sizeBytes, err := testCache.Get(kind, hash)
+	rdr, sizeBytes, err := testCache.Get(kind, hash)
 	if err != nil {
 		return err
 	}
 	// Get the item back
-	return expectContentEquals(data, sizeBytes, []byte(content))
+	return expectContentEquals(rdr, sizeBytes, []byte(content))
 }
 
 func hashStr(content string) string {

--- a/cache/http/http.go
+++ b/cache/http/http.go
@@ -33,17 +33,17 @@ type remoteHTTPProxyCache struct {
 
 func uploadFile(remote *http.Client, baseURL *url.URL, local cache.Cache, accessLogger cache.Logger,
 	errorLogger cache.Logger, hash string, kind cache.EntryKind) {
-	data, size, err := local.Get(kind, hash)
+	rdr, size, err := local.Get(kind, hash)
 	if err != nil {
 		return
 	}
 
 	if size == 0 {
 		// See https://github.com/golang/go/issues/20257#issuecomment-299509391
-		data = http.NoBody
+		rdr = http.NoBody
 	}
 	url := requestURL(baseURL, hash, kind)
-	req, err := http.NewRequest(http.MethodPut, url, data)
+	req, err := http.NewRequest(http.MethodPut, url, rdr)
 	if err != nil {
 		return
 	}
@@ -85,12 +85,12 @@ func logResponse(log cache.Logger, method string, code int, url string) {
 	log.Printf("%4s %d %15s %s", method, code, "", url)
 }
 
-func (r *remoteHTTPProxyCache) Put(kind cache.EntryKind, hash string, size int64, data io.Reader) (error) {
+func (r *remoteHTTPProxyCache) Put(kind cache.EntryKind, hash string, size int64, rdr io.Reader) error {
 	if r.local.Contains(kind, hash) {
-		io.Copy(ioutil.Discard, data)
+		io.Copy(ioutil.Discard, rdr)
 		return nil
 	}
-	err := r.local.Put(kind, hash, size, data)
+	err := r.local.Put(kind, hash, size, rdr)
 	if err != nil {
 		return err
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -105,7 +105,7 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch m := r.Method; m {
 	case http.MethodGet:
-		data, sizeBytes, err := h.cache.Get(kind, hash)
+		rdr, sizeBytes, err := h.cache.Get(kind, hash)
 		if err != nil {
 			if e, ok := err.(*cache.Error); ok {
 				http.Error(w, e.Error(), e.Code)
@@ -116,16 +116,16 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if data == nil {
+		if rdr == nil {
 			http.Error(w, "Not found", http.StatusNotFound)
 			logResponse(http.StatusNotFound)
 			return
 		}
-		defer data.Close()
+		defer rdr.Close()
 
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.FormatInt(sizeBytes, 10))
-		io.Copy(w, data)
+		io.Copy(w, rdr)
 
 		logResponse(http.StatusOK)
 	case http.MethodPut:

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -303,7 +303,7 @@ func (f *fakeCache) Put(kind cache.EntryKind, hash string, size int64, r io.Read
 	return nil
 }
 
-func (f *fakeCache) Get(kind cache.EntryKind, hash string) (data io.ReadCloser, sizeBytes int64, err error) {
+func (f *fakeCache) Get(kind cache.EntryKind, hash string) (rdr io.ReadCloser, sizeBytes int64, err error) {
 	return nil, -1, &cache.Error{
 		Code: http.StatusNotFound,
 		Text: fmt.Sprintf("Not found\n"),


### PR DESCRIPTION
I tended to assume that these "data" variables were byte slices.
rdr seems like a more obvious name.

Cleanup before implementing #106.