### PR TITLE
validate ActionCache items before returning them for http also

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ GLOBAL OPTIONS:
    --s3.access_key_id value      The S3/minio access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_ACCESS_KEY_ID]
    --s3.secret_access_key value  The S3/minio secret access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
    --s3.disable_ssl              Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL). [$BAZEL_REMOTE_S3_DISABLE_SSL]
+   --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation). [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
    --help, -h                    show help
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
@@ -106,8 +105,8 @@ go_repository(
 go_repository(
     # minio has this dependency
     name = "com_github_go_ini_ini",
-    importpath="github.com/go-ini/ini",
-    commit="9c8236e659b76e87bf02044d06fde8683008ff3e",
+    importpath = "github.com/go-ini/ini",
+    commit = "9c8236e659b76e87bf02044d06fde8683008ff3e",
 )
 
 go_repository(

--- a/cache/BUILD.bazel
+++ b/cache/BUILD.bazel
@@ -5,4 +5,8 @@ go_library(
     srcs = ["cache.go"],
     importpath = "github.com/buchgr/bazel-remote/cache",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
 )

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -51,6 +51,10 @@ func New(dir string, maxSizeBytes int64) cache.Cache {
 			if err != nil {
 				log.Fatal(err)
 			}
+			err = os.MkdirAll(filepath.Join(dir, cache.RAW.String(), subDir), os.FileMode(0744))
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 
@@ -93,6 +97,7 @@ func (c *diskCache) migrateDirectories() error {
 	if err != nil {
 		return err
 	}
+	// Note: there are no old "RAW" directories (yet).
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,37 +31,39 @@ type HTTPBackendConfig struct {
 
 // Config provides the configuration
 type Config struct {
-	Host               string                    `yaml:"host"`
-	Port               int                       `yaml:"port"`
-	GRPCPort           int                       `yaml:"grpc_port"`
-	Dir                string                    `yaml:"dir"`
-	MaxSize            int                       `yaml:"max_size"`
-	HtpasswdFile       string                    `yaml:"htpasswd_file"`
-	TLSCertFile        string                    `yaml:"tls_cert_file"`
-	TLSKeyFile         string                    `yaml:"tls_key_file"`
-	S3CloudStorage     *S3CloudStorageConfig     `yaml:"s3_proxy"`
-	GoogleCloudStorage *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
-	HTTPBackend        *HTTPBackendConfig        `yaml:"http_proxy"`
-	IdleTimeout        time.Duration             `yaml:"idle_timeout"`
+	Host                    string                    `yaml:"host"`
+	Port                    int                       `yaml:"port"`
+	GRPCPort                int                       `yaml:"grpc_port"`
+	Dir                     string                    `yaml:"dir"`
+	MaxSize                 int                       `yaml:"max_size"`
+	HtpasswdFile            string                    `yaml:"htpasswd_file"`
+	TLSCertFile             string                    `yaml:"tls_cert_file"`
+	TLSKeyFile              string                    `yaml:"tls_key_file"`
+	S3CloudStorage          *S3CloudStorageConfig     `yaml:"s3_proxy"`
+	GoogleCloudStorage      *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
+	HTTPBackend             *HTTPBackendConfig        `yaml:"http_proxy"`
+	IdleTimeout             time.Duration             `yaml:"idle_timeout"`
+	DisableHTTPACValidation bool                      `yaml:"disable_http_ac_validation"`
 }
 
 // New ...
 func New(dir string, maxSize int, host string, port int, grpc_port int, htpasswdFile string,
 	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration,
-	s3 *S3CloudStorageConfig) (*Config, error) {
+	s3 *S3CloudStorageConfig, disable_http_ac_validation bool) (*Config, error) {
 	c := Config{
-		Host:               host,
-		Port:               port,
-		GRPCPort:           grpc_port,
-		Dir:                dir,
-		MaxSize:            maxSize,
-		HtpasswdFile:       htpasswdFile,
-		TLSCertFile:        tlsCertFile,
-		TLSKeyFile:         tlsKeyFile,
-		S3CloudStorage:     s3,
-		GoogleCloudStorage: nil,
-		HTTPBackend:        nil,
-		IdleTimeout:        idleTimeout,
+		Host:                    host,
+		Port:                    port,
+		GRPCPort:                grpc_port,
+		Dir:                     dir,
+		MaxSize:                 maxSize,
+		HtpasswdFile:            htpasswdFile,
+		TLSCertFile:             tlsCertFile,
+		TLSKeyFile:              tlsKeyFile,
+		S3CloudStorage:          s3,
+		GoogleCloudStorage:      nil,
+		HTTPBackend:             nil,
+		IdleTimeout:             idleTimeout,
+		DisableHTTPACValidation: disable_http_ac_validation,
 	}
 
 	err := validateConfig(&c)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ max_size: 100
 htpasswd_file: /opt/.htpasswd
 tls_cert_file: /opt/tls.cert
 tls_key_file:  /opt/tls.key
+disable_http_ac_validation: true
 `
 
 	config, err := newFromYaml([]byte(yaml))
@@ -25,14 +26,15 @@ tls_key_file:  /opt/tls.key
 	}
 
 	expectedConfig := &Config{
-		Host:         "localhost",
-		Port:         8080,
-		GRPCPort:     9092,
-		Dir:          "/opt/cache-dir",
-		MaxSize:      100,
-		HtpasswdFile: "/opt/.htpasswd",
-		TLSCertFile:  "/opt/tls.cert",
-		TLSKeyFile:   "/opt/tls.key",
+		Host:                    "localhost",
+		Port:                    8080,
+		GRPCPort:                9092,
+		Dir:                     "/opt/cache-dir",
+		MaxSize:                 100,
+		HtpasswdFile:            "/opt/.htpasswd",
+		TLSCertFile:             "/opt/tls.cert",
+		TLSKeyFile:              "/opt/tls.key",
+		DisableHTTPACValidation: true,
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {

--- a/main.go
+++ b/main.go
@@ -135,6 +135,11 @@ func main() {
 			Usage:  "Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL).",
 			EnvVar: "BAZEL_REMOTE_S3_DISABLE_SSL",
 		},
+		cli.BoolFlag{
+			Name:   "disable_http_ac_validation",
+			Usage:  "Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation).",
+			EnvVar: "BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION",
+		},
 	}
 
 	app.Action = func(ctx *cli.Context) error {
@@ -166,6 +171,7 @@ func main() {
 				ctx.String("tls_key_file"),
 				ctx.Duration("idle_timeout"),
 				s3,
+				ctx.Bool("disable_http_ac_validation"),
 			)
 		}
 
@@ -207,7 +213,8 @@ func main() {
 			Addr:    c.Host + ":" + strconv.Itoa(c.Port),
 			Handler: mux,
 		}
-		h := server.NewHTTPCache(proxyCache, accessLogger, errorLogger)
+		validateAC := !c.DisableHTTPACValidation
+		h := server.NewHTTPCache(proxyCache, accessLogger, errorLogger, validateAC)
 		mux.HandleFunc("/status", h.StatusPageHandler)
 
 		cacheHandler := h.CacheHandler

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 
 	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/golang/protobuf/proto"
@@ -25,72 +24,17 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 		return nil, err
 	}
 
-	dr, _, err := s.cache.Get(cache.AC, req.ActionDigest.Hash)
+	result, _, err := cache.GetValidatedActionResult(s.cache,
+		req.ActionDigest.Hash)
 	if err != nil {
 		s.accessLogger.Printf("%s %s %s", errorPrefix, req.ActionDigest.Hash, err)
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
-	if dr == nil {
+
+	if result == nil {
 		s.accessLogger.Printf("%s %s NOT FOUND", errorPrefix, req.ActionDigest.Hash)
 		return nil, status.Error(codes.NotFound,
 			fmt.Sprintf("%s not found in AC", req.ActionDigest.Hash))
-	}
-
-	// Note: req.ActionDigest refers to the Action, not the ActionResult.
-	// There's nothing useful we can do with req.ActionDigest.SizeBytes.
-
-	data, err := ioutil.ReadAll(dr)
-	if err != nil {
-		s.accessLogger.Printf("%s %s %s", errorPrefix, req.ActionDigest.Hash, err)
-		return nil, status.Error(codes.Unknown, err.Error())
-	}
-
-	result := &pb.ActionResult{}
-	err = proto.Unmarshal(data, result)
-	if err != nil {
-		// Invalid cache item?
-		s.accessLogger.Printf("%s %s %s", errorPrefix, req.ActionDigest.Hash, err)
-		return nil, status.Error(codes.DataLoss, err.Error())
-	}
-
-	// Check that referenced blobs are available.
-
-	for _, f := range result.OutputFiles {
-		if len(f.Contents) == 0 && f.Digest.SizeBytes > 0 {
-			if !s.cache.Contains(cache.CAS, f.Digest.Hash) {
-				s.accessLogger.Printf("GRPC CAS CONTAINS %s NOT FOUND",
-					f.Digest.Hash)
-				return nil, status.Error(codes.NotFound,
-					fmt.Sprintf("%s not found in CAS", f.Digest.Hash))
-			}
-		}
-	}
-
-	for _, d := range result.OutputDirectories {
-		if !s.cache.Contains(cache.CAS, d.TreeDigest.Hash) {
-			s.accessLogger.Printf("GRPC CAS CONTAINS %s NOT FOUND",
-				d.TreeDigest.Hash)
-			return nil, status.Error(codes.NotFound,
-				fmt.Sprintf("%s not found in CAS", d.TreeDigest.Hash))
-		}
-	}
-
-	if result.StdoutDigest != nil {
-		if !s.cache.Contains(cache.CAS, result.StdoutDigest.Hash) {
-			s.accessLogger.Printf("GRPC CAS CONTAINS %s NOT FOUND",
-				result.StdoutDigest.Hash)
-			return nil, status.Error(codes.NotFound,
-				fmt.Sprintf("%s not found in CAS", result.StdoutDigest.Hash))
-		}
-	}
-
-	if result.StderrDigest != nil {
-		if !s.cache.Contains(cache.CAS, result.StderrDigest.Hash) {
-			s.accessLogger.Printf("GRPC CAS CONTAINS %s NOT FOUND",
-				result.StderrDigest.Hash)
-			return nil, status.Error(codes.NotFound,
-				fmt.Sprintf("%s not found in CAS", result.StderrDigest.Hash))
-		}
 	}
 
 	s.accessLogger.Printf("GRPC AC GET %s OK", req.ActionDigest.Hash)


### PR DESCRIPTION
A common bug is the scenario where an ActionResult exists in the
ActionCache and is returned to the client, but not all the blobs
that it depends on are available in the CAS when the client tries
to get them. The client typically errors out at this point, and
might also continue failing when re-run, until the ActionResult
is removed from the cache.

To avoid this problem, we should verify that all the required
blobs are available before returning a given ActionCache. Doing
so should move these items to the "safe" end of the LRU queue,
and increase the odds that the CAS blobs will still exist in the
cache when the client requests them.

We previously had this check in the gRPC interface, but not for
the REST interface. This change refactors the check so it's
available to the REST interface. Since some clients might be
relying on bazel-remote to store arbitrary non-ActionResult blobs
in the ActionCache via the REST interface, we provide a command
line flag to disable this validation:
--disable_http_ac_validation

When --disable_http_ac_validation is specified, ActionCache blobs
uploaded and downloaded via REST are stored in a new "raw"
keyspace to avoid clashes with validated gRPC ActionResult blobs
(which are always validated and always stored in the "ac" keyspace).

If you want to use --disable_http_ac_validation and not lose access
to existing cache items, stop bazel-remote, rename the "ac" dir to
"raw", then restart bazel-remote with --disable_http_ac_validation.