### PR TITLE
print all logs with UTC timestamps

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,14 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const (
+	logFlags = log.Ldate | log.Ltime | log.LUTC
+)
+
 func main() {
+
+	log.SetFlags(logFlags)
+
 	app := cli.NewApp()
 	app.Description = "A remote build cache for Bazel."
 	app.Usage = "A remote build cache for Bazel"
@@ -181,8 +188,8 @@ func main() {
 			return nil
 		}
 
-		accessLogger := log.New(os.Stdout, "", log.Ldate|log.Ltime|log.LUTC)
-		errorLogger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.LUTC)
+		accessLogger := log.New(os.Stdout, "", logFlags)
+		errorLogger := log.New(os.Stderr, "", logFlags)
 
 		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024)
 


### PR DESCRIPTION
The cache accessLogger and errorLoggers use specific flags to specify
the time format and timezone to use (UTC). However, stray log.Printf
etc calls during startup did not use the same settings, and defaulted
to printing times relative to the local timezone.