### PR TITLE
read and close http.Response.Body to allow keep-alive connection reuse

### DIFF
--- a/cache/http/http.go
+++ b/cache/http/http.go
@@ -54,6 +54,9 @@ func uploadFile(remote *http.Client, baseURL *url.URL, local cache.Cache, access
 	if err != nil {
 		return
 	}
+	io.Copy(ioutil.Discard, rsp.Body)
+	rsp.Body.Close()
+
 	logResponse(accessLogger, "PUT", rsp.StatusCode, url)
 	return
 }


### PR DESCRIPTION
rsp.Body is guaranteed to be non-nil, and should be read to completion
(or error) and then closed. Ref:
https://github.com/golang/go/blob/6becb033341602f2df9d7c55cc23e64b925bbee2/src/net/http/response.go#L59

Fixes #104.