### PR TITLE
log git commit earlier in the startup process

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# Include git version info
+build --stamp
+build --workspace_status_command 'echo STABLE_GIT_COMMIT $(git rev-parse HEAD)'

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,7 +34,7 @@ go_binary(
     pure = "on",
     static = "on",
     visibility = ["//visibility:public"],
-    x_defs = {"github.com/buchgr/bazel-remote/server.GitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
 )
 
 go_image(

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -3,6 +3,6 @@
 set -euxo pipefail
 
 VERSION_TAG="$(git rev-parse HEAD)"
-VERSION_LINK_FLAG="github.com/buchgr/bazel-remote/server.GitCommit=${VERSION_TAG}"
+VERSION_LINK_FLAG="main.gitCommit=${VERSION_TAG}"
 
 CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-extldflags '-static' -X ${VERSION_LINK_FLAG}" .

--- a/main.go
+++ b/main.go
@@ -31,9 +31,17 @@ const (
 	logFlags = log.Ldate | log.Ltime | log.LUTC
 )
 
+// gitCommit is the version stamp for the server. The value of this var
+// is set through linker options.
+var gitCommit string
+
 func main() {
 
 	log.SetFlags(logFlags)
+
+	if len(gitCommit) > 0 && gitCommit != "{STABLE_GIT_COMMIT}" {
+		log.Printf("bazel-remote built from git commit %s.", gitCommit)
+	}
 
 	app := cli.NewApp()
 	app.Description = "A remote build cache for Bazel."
@@ -221,7 +229,7 @@ func main() {
 			Handler: mux,
 		}
 		validateAC := !c.DisableHTTPACValidation
-		h := server.NewHTTPCache(proxyCache, accessLogger, errorLogger, validateAC)
+		h := server.NewHTTPCache(proxyCache, accessLogger, errorLogger, validateAC, gitCommit)
 		mux.HandleFunc("/status", h.StatusPageHandler)
 
 		cacheHandler := h.CacheHandler

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -32,7 +32,7 @@ func TestDownloadFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 1024)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 
 	req, err := http.NewRequest("GET", "/cas/"+hash, bytes.NewReader([]byte{}))
 	if err != nil {
@@ -83,7 +83,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 1000*1024)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -139,7 +139,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	data, hash := testutils.RandomDataAndHash(1024)
 
 	c := disk.New(cacheDir, 1024)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -184,7 +184,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -225,7 +225,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 
 	c := disk.New(cacheDir, 2048)
 	validate := true
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -263,7 +263,7 @@ func TestStatusPage(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -399,7 +399,7 @@ func (r fakeResponseWriter) WriteHeader(statusCode int) {
 
 func TestRemoteReturnsNotFound(t *testing.T) {
 	fake := &fakeCache{}
-	h := NewHTTPCache(fake, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true)
+	h := NewHTTPCache(fake, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))


### PR DESCRIPTION
I also had to dig around a bit to figure out how to make bazel inject this value, I found the answer over in https://github.com/bazelbuild/rules_go/issues/2224