### PR TITLE
simplify wrapIdleHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,6 +290,7 @@ func wrapIdleHandler(handler http.HandlerFunc, idleTimeout time.Duration, access
 	lastRequest := time.Now()
 	ticker := time.NewTicker(time.Second)
 	var mu sync.Mutex
+
 	go func() {
 		for now := range ticker.C {
 			mu.Lock()
@@ -299,9 +300,11 @@ func wrapIdleHandler(handler http.HandlerFunc, idleTimeout time.Duration, access
 				ticker.Stop()
 				accessLogger.Printf("Shutting down server after having been idle for %v", idleTimeout)
 				httpServer.Shutdown(context.Background())
+				return
 			}
 		}
 	}()
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		now := time.Now()
 		mu.Lock()


### PR DESCRIPTION
Instead of using select with only a single case, we can simply range
over the ticker channel.

Also, use the de-facto standard variable name for mutexes in Go code, "mu".

ticker.Stop() does not close the channel, so this goroutine would block
forever (or at least until shutdown). It may as well just return.