### PR TITLE
add back mac CI testing

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,3 +6,9 @@ platforms:
     test_targets:
     - "..."
   ubuntu1804: *anchor
+  macos:
+    build_targets:
+    # Skip the (linux) container image targets, just build the binary.
+    - "//:bazel-remote"
+    test_targets:
+    - "..."


### PR DESCRIPTION
This was removed from our CI setup due to infra problems. Let's see if they have been resolved.