### PR TITLE
upgrade github.com/urfave/cli to v2

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "//config:go_default_library",
         "//server:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",
-        "@com_github_urfave_cli//:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,10 +97,10 @@ go_repository(
 )
 
 go_repository(
-    name = "com_github_urfave_cli",
-    importpath = "github.com/urfave/cli",
-    sum = "h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=",
-    version = "v1.22.2",
+    name = "com_github_urfave_cli_v2",
+    importpath = "github.com/urfave/cli/v2",
+    sum = "h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=",
+    version = "v2.1.1",
 )
 
 go_repository(

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/minio/minio-go/v6 v6.0.44
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/urfave/cli v1.22.2
+	github.com/urfave/cli/v2 v2.1.1
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 // indirect
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
-github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
+github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/buchgr/bazel-remote/config"
 	"github.com/buchgr/bazel-remote/server"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -49,111 +49,111 @@ func main() {
 	app.HideVersion = true
 
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
+		&cli.StringFlag{
 			Name:  "config_file",
 			Value: "",
 			Usage: "Path to a YAML configuration file. If this flag is specified then all other flags " +
 				"are ignored.",
-			EnvVar: "BAZEL_REMOTE_CONFIG_FILE",
+			EnvVars: []string{"BAZEL_REMOTE_CONFIG_FILE"},
 		},
-		cli.StringFlag{
-			Name:   "dir",
-			Value:  "",
-			Usage:  "Directory path where to store the cache contents. This flag is required.",
-			EnvVar: "BAZEL_REMOTE_DIR",
+		&cli.StringFlag{
+			Name:    "dir",
+			Value:   "",
+			Usage:   "Directory path where to store the cache contents. This flag is required.",
+			EnvVars: []string{"BAZEL_REMOTE_DIR"},
 		},
-		cli.Int64Flag{
-			Name:   "max_size",
-			Value:  -1,
-			Usage:  "The maximum size of the remote cache in GiB. This flag is required.",
-			EnvVar: "BAZEL_REMOTE_MAX_SIZE",
+		&cli.Int64Flag{
+			Name:    "max_size",
+			Value:   -1,
+			Usage:   "The maximum size of the remote cache in GiB. This flag is required.",
+			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE"},
 		},
-		cli.StringFlag{
-			Name:   "host",
-			Value:  "",
-			Usage:  "Address to listen on. Listens on all network interfaces by default.",
-			EnvVar: "BAZEL_REMOTE_HOST",
+		&cli.StringFlag{
+			Name:    "host",
+			Value:   "",
+			Usage:   "Address to listen on. Listens on all network interfaces by default.",
+			EnvVars: []string{"BAZEL_REMOTE_HOST"},
 		},
-		cli.IntFlag{
-			Name:   "port",
-			Value:  8080,
-			Usage:  "The port the HTTP server listens on.",
-			EnvVar: "BAZEL_REMOTE_PORT",
+		&cli.IntFlag{
+			Name:    "port",
+			Value:   8080,
+			Usage:   "The port the HTTP server listens on.",
+			EnvVars: []string{"BAZEL_REMOTE_PORT"},
 		},
-		cli.IntFlag{
-			Name:   "grpc_port",
-			Value:  9092,
-			Usage:  "The port the EXPERIMENTAL gRPC server listens on. Set to 0 to disable.",
-			EnvVar: "BAZEL_REMOTE_GRPC_PORT",
+		&cli.IntFlag{
+			Name:    "grpc_port",
+			Value:   9092,
+			Usage:   "The port the EXPERIMENTAL gRPC server listens on. Set to 0 to disable.",
+			EnvVars: []string{"BAZEL_REMOTE_GRPC_PORT"},
 		},
-		cli.StringFlag{
-			Name:   "htpasswd_file",
-			Value:  "",
-			Usage:  "Path to a .htpasswd file. This flag is optional. Please read https://httpd.apache.org/docs/2.4/programs/htpasswd.html.",
-			EnvVar: "BAZEL_REMOTE_HTPASSWD_FILE",
+		&cli.StringFlag{
+			Name:    "htpasswd_file",
+			Value:   "",
+			Usage:   "Path to a .htpasswd file. This flag is optional. Please read https://httpd.apache.org/docs/2.4/programs/htpasswd.html.",
+			EnvVars: []string{"BAZEL_REMOTE_HTPASSWD_FILE"},
 		},
-		cli.BoolFlag{
-			Name:   "tls_enabled",
-			Usage:  "This flag has been deprecated. Specify tls_cert_file and tls_key_file instead.",
-			EnvVar: "BAZEL_REMOTE_TLS_ENABLED",
+		&cli.BoolFlag{
+			Name:    "tls_enabled",
+			Usage:   "This flag has been deprecated. Specify tls_cert_file and tls_key_file instead.",
+			EnvVars: []string{"BAZEL_REMOTE_TLS_ENABLED"},
 		},
-		cli.StringFlag{
-			Name:   "tls_cert_file",
-			Value:  "",
-			Usage:  "Path to a pem encoded certificate file.",
-			EnvVar: "BAZEL_REMOTE_TLS_CERT_FILE",
+		&cli.StringFlag{
+			Name:    "tls_cert_file",
+			Value:   "",
+			Usage:   "Path to a pem encoded certificate file.",
+			EnvVars: []string{"BAZEL_REMOTE_TLS_CERT_FILE"},
 		},
-		cli.StringFlag{
-			Name:   "tls_key_file",
-			Value:  "",
-			Usage:  "Path to a pem encoded key file.",
-			EnvVar: "BAZEL_REMOTE_TLS_KEY_FILE",
+		&cli.StringFlag{
+			Name:    "tls_key_file",
+			Value:   "",
+			Usage:   "Path to a pem encoded key file.",
+			EnvVars: []string{"BAZEL_REMOTE_TLS_KEY_FILE"},
 		},
-		cli.DurationFlag{
-			Name:   "idle_timeout",
-			Value:  0,
-			Usage:  "The maximum period of having received no request after which the server will shut itself down. Disabled by default.",
-			EnvVar: "BAZEL_REMOTE_IDLE_TIMEOUT",
+		&cli.DurationFlag{
+			Name:    "idle_timeout",
+			Value:   0,
+			Usage:   "The maximum period of having received no request after which the server will shut itself down. Disabled by default.",
+			EnvVars: []string{"BAZEL_REMOTE_IDLE_TIMEOUT"},
 		},
-		cli.StringFlag{
-			Name:   "s3.endpoint",
-			Value:  "",
-			Usage:  "The S3/minio endpoint to use when using S3 cache backend.",
-			EnvVar: "BAZEL_REMOTE_S3_ENDPOINT",
+		&cli.StringFlag{
+			Name:    "s3.endpoint",
+			Value:   "",
+			Usage:   "The S3/minio endpoint to use when using S3 cache backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_ENDPOINT"},
 		},
-		cli.StringFlag{
-			Name:   "s3.bucket",
-			Value:  "",
-			Usage:  "The S3/minio bucket to use when using S3 cache backend.",
-			EnvVar: "BAZEL_REMOTE_S3_BUCKET",
+		&cli.StringFlag{
+			Name:    "s3.bucket",
+			Value:   "",
+			Usage:   "The S3/minio bucket to use when using S3 cache backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_BUCKET"},
 		},
-		cli.StringFlag{
-			Name:   "s3.prefix",
-			Value:  "",
-			Usage:  "The S3/minio object prefix to use when using S3 cache backend.",
-			EnvVar: "BAZEL_REMOTE_S3_PREFIX",
+		&cli.StringFlag{
+			Name:    "s3.prefix",
+			Value:   "",
+			Usage:   "The S3/minio object prefix to use when using S3 cache backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_PREFIX"},
 		},
-		cli.StringFlag{
-			Name:   "s3.access_key_id",
-			Value:  "",
-			Usage:  "The S3/minio access key to use when using S3 cache backend.",
-			EnvVar: "BAZEL_REMOTE_S3_ACCESS_KEY_ID",
+		&cli.StringFlag{
+			Name:    "s3.access_key_id",
+			Value:   "",
+			Usage:   "The S3/minio access key to use when using S3 cache backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_ACCESS_KEY_ID"},
 		},
-		cli.StringFlag{
-			Name:   "s3.secret_access_key",
-			Value:  "",
-			Usage:  "The S3/minio secret access key to use when using S3 cache backend.",
-			EnvVar: "BAZEL_REMOTE_S3_SECRET_ACCESS_KEY",
+		&cli.StringFlag{
+			Name:    "s3.secret_access_key",
+			Value:   "",
+			Usage:   "The S3/minio secret access key to use when using S3 cache backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_SECRET_ACCESS_KEY"},
 		},
-		cli.BoolFlag{
-			Name:   "s3.disable_ssl",
-			Usage:  "Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL).",
-			EnvVar: "BAZEL_REMOTE_S3_DISABLE_SSL",
+		&cli.BoolFlag{
+			Name:    "s3.disable_ssl",
+			Usage:   "Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL).",
+			EnvVars: []string{"BAZEL_REMOTE_S3_DISABLE_SSL"},
 		},
-		cli.BoolFlag{
-			Name:   "disable_http_ac_validation",
-			Usage:  "Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation).",
-			EnvVar: "BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION",
+		&cli.BoolFlag{
+			Name:    "disable_http_ac_validation",
+			Usage:   "Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation).",
+			EnvVars: []string{"BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION"},
 		},
 	}
 


### PR DESCRIPTION
github.com/urfave/cli introduced an API breaking change from v1 to v2
on the master branch. Unfortunately, there's no canonical way to refer
to v1 without modules (or similar).

We have been using v1 on an older part of the master branch, which
built OK with bazel or with go modules, but failed to build without
go modules (go get github.com/buchgr/bazel-remote, inside GOPATH).

By upgrading to v2 we can build successfully in all three modes.

Fixes #133.