### PR TITLE
Differentiate Action Cache objects by instance name

### DIFF
--- a/cache/http/http_test.go
+++ b/cache/http/http_test.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/buchgr/bazel-remote/cache"
 	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/utils"
+	testutils "github.com/buchgr/bazel-remote/utils"
 )
+
+const noInstanceName = ""
 
 func TestProxyReadWorks(t *testing.T) {
 	// Test that reading a blob from a proxy works and also populates the local
@@ -41,11 +43,11 @@ func TestProxyReadWorks(t *testing.T) {
 
 	hashBytes := sha256.Sum256(expectedData)
 	hash := hex.EncodeToString(hashBytes[:])
-	if diskCache.Contains(cache.CAS, hash) {
+	if diskCache.Contains(cache.CAS, noInstanceName, hash) {
 		t.Fatalf("Expected the local cache to be empty")
 	}
 
-	readBytes, actualSizeBytes, err := proxy.Get(cache.CAS, hash)
+	readBytes, actualSizeBytes, err := proxy.Get(cache.CAS, noInstanceName, hash)
 	if err != nil {
 		t.Fatalf("Failed to get the blob via the http proxy: '%v'", err)
 	}
@@ -64,7 +66,7 @@ func TestProxyReadWorks(t *testing.T) {
 			len(expectedData))
 	}
 
-	if !diskCache.Contains(cache.CAS, hash) {
+	if !diskCache.Contains(cache.CAS, noInstanceName, hash) {
 		t.Fatalf("Expected the blob to be cached locally.")
 	}
 }
@@ -106,16 +108,16 @@ func TestProxyWriteWorks(t *testing.T) {
 	proxy := New(baseURL, diskCache, &http.Client{}, testutils.NewSilentLogger(),
 		testutils.NewSilentLogger())
 
-	if diskCache.Contains(cache.CAS, hash) {
+	if diskCache.Contains(cache.CAS, noInstanceName, hash) {
 		t.Fatalf("Expected the local cache to be empty")
 	}
 
-	err = proxy.Put(cache.CAS, hash, int64(len(data)), bytes.NewReader(data))
+	err = proxy.Put(cache.CAS, noInstanceName, hash, int64(len(data)), bytes.NewReader(data))
 	if err != nil {
 		t.Errorf("Failed to write to the proxy: '%v'", err)
 	}
 
-	if !diskCache.Contains(cache.CAS, hash) {
+	if !diskCache.Contains(cache.CAS, noInstanceName, hash) {
 		t.Fatalf("Expected the local cache to contain '%s'", hash)
 	}
 }
@@ -144,7 +146,7 @@ func TestProxyReadErrorsArePropagated(t *testing.T) {
 	proxy := New(baseURL, diskCache, &http.Client{}, testutils.NewSilentLogger(),
 		testutils.NewSilentLogger())
 
-	_, _, err = proxy.Get(cache.CAS, hash)
+	_, _, err = proxy.Get(cache.CAS, noInstanceName, hash)
 	if cerr, ok := err.(*cache.Error); ok {
 		if cerr.Code != http.StatusForbidden {
 			t.Errorf("Expected error code '%d' but got '%d'", http.StatusForbidden, cerr.Code)
@@ -183,12 +185,12 @@ func TestProxyWriteErrorsAreNotPropagated(t *testing.T) {
 	proxy := New(baseURL, diskCache, &http.Client{}, testutils.NewSilentLogger(),
 		testutils.NewSilentLogger())
 
-	err = proxy.Put(cache.CAS, hash, int64(len(data)), bytes.NewReader(data))
+	err = proxy.Put(cache.CAS, noInstanceName, hash, int64(len(data)), bytes.NewReader(data))
 	if err != nil {
 		t.Error("Expected the error on put to not be propagated")
 	}
 
-	if !diskCache.Contains(cache.CAS, hash) {
+	if !diskCache.Contains(cache.CAS, noInstanceName, hash) {
 		t.Error("Expected the blob to be stored locally")
 	}
 }
@@ -219,12 +221,12 @@ func TestProxyLocalPutFailuresNotRelayed(t *testing.T) {
 	proxy := New(baseURL, diskCache, &http.Client{}, testutils.NewSilentLogger(),
 		testutils.NewSilentLogger())
 
-	err = proxy.Put(cache.AC, hash, int64(len(data)+1), bytes.NewReader(data))
+	err = proxy.Put(cache.AC, noInstanceName, hash, int64(len(data)+1), bytes.NewReader(data))
 	if err == nil {
 		t.Error("Expected Put to error with size miss-match")
 	}
 
-	if diskCache.Contains(cache.AC, hash) {
+	if diskCache.Contains(cache.AC, noInstanceName, hash) {
 		t.Error("Expected not to be stored locally")
 	}
 }


### PR DESCRIPTION
Hello,

Every now and then a Clang update in our toolchain breaks the remote caching (usually fiffreneces in system headers like clang version numbers jumping from `7.0.0` to `7.1.0`). A suggested work-around is to separate the caches.

For http this is possible with `--remote_cache=http://localhost:8080/foo` and for grpc by setting `--remote_instance_name=bar`.

For now the instance name only affects the action cache because in my use case the CAS content cannot differ.

I'd appreciate some feedback. (I'm also a golang beginner - please bear with me)

Thanks,
Gregor

Fixes: #15