### PR TITLE
add an optional http profiling endpoint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -56,6 +56,12 @@ container_image(
         "/app/bazel-remote-base.binary",
         "--port=8080",
         "--dir=/data",
+
+        # Listen on all addresses, not just 127.0.0.1, so this can
+        # be reached from outside the container (with a -p mapping).
+        "--profile_host=",
+        # Specify a port to enable the profiling http server.
+        "--profile_port=6060",
     ],
     ports = ["8080"],
     visibility = ["//visibility:public"],

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ GLOBAL OPTIONS:
    --host value                  Address to listen on. Listens on all network interfaces by default. [$BAZEL_REMOTE_HOST]
    --port value                  The port the HTTP server listens on. (default: 8080) [$BAZEL_REMOTE_PORT]
    --grpc_port value             The port the EXPERIMENTAL gRPC server listens on. Set to 0 to disable. (default: 9092) [$BAZEL_REMOTE_GRPC_PORT]
+   --profile_host value          A host address to listen on for profiling, if enabled by a valid --profile_port setting. (default: "127.0.0.1") [$BAZEL_REMOTE_PROFILE_HOST]
+   --profile_port value          If a positive integer, serve /debug/pprof/* URLs from http://profile_host:profile_port. (default: 0) [$BAZEL_REMOTE_PROFILE_PORT]
    --htpasswd_file value         Path to a .htpasswd file. This flag is optional. Please read https://httpd.apache.org/docs/2.4/programs/htpasswd.html. [$BAZEL_REMOTE_HTPASSWD_FILE]
    --tls_enabled                 This flag has been deprecated. Specify tls_cert_file and tls_key_file instead. [$BAZEL_REMOTE_TLS_ENABLED]
    --tls_cert_file value         Path to a pem encoded certificate file. [$BAZEL_REMOTE_TLS_CERT_FILE]
@@ -116,6 +118,17 @@ $ docker run -v /path/to/cache/dir:/data \
 --tls_cert_file=/etc/bazel-remote/server_cert --tls_key_file=/etc/bazel-remote/server_key \
 --htpasswd_file /etc/bazel-remote/htpasswd --max_size=5
 ```
+
+### Profiling
+
+To enable the profiling, specify a port with `--profile_port`.
+
+If running inside docker, you will also need to set `--profile_host` to a
+value other than `127.0.0.1` (`--profile_host=` with an empty value should
+work) and add a `-p` mapping to the docker run commandline for the port.
+
+See [Profiling Go programs with pprof](https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/)
+for more details.
 
 ## Configuring Bazel
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ DESCRIPTION:
    A remote build cache for Bazel.
 
 COMMANDS:
-     help, h  Shows a list of commands or help for one command
+   help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --config_file value           Path to a YAML configuration file. If this flag is specified then all other flags are ignored. [$BAZEL_REMOTE_CONFIG_FILE]
@@ -58,7 +58,7 @@ GLOBAL OPTIONS:
    --profile_host value          A host address to listen on for profiling, if enabled by a valid --profile_port setting. (default: "127.0.0.1") [$BAZEL_REMOTE_PROFILE_HOST]
    --profile_port value          If a positive integer, serve /debug/pprof/* URLs from http://profile_host:profile_port. (default: 0) [$BAZEL_REMOTE_PROFILE_PORT]
    --htpasswd_file value         Path to a .htpasswd file. This flag is optional. Please read https://httpd.apache.org/docs/2.4/programs/htpasswd.html. [$BAZEL_REMOTE_HTPASSWD_FILE]
-   --tls_enabled                 This flag has been deprecated. Specify tls_cert_file and tls_key_file instead. [$BAZEL_REMOTE_TLS_ENABLED]
+   --tls_enabled                 This flag has been deprecated. Specify tls_cert_file and tls_key_file instead. (default: false) [$BAZEL_REMOTE_TLS_ENABLED]
    --tls_cert_file value         Path to a pem encoded certificate file. [$BAZEL_REMOTE_TLS_CERT_FILE]
    --tls_key_file value          Path to a pem encoded key file. [$BAZEL_REMOTE_TLS_KEY_FILE]
    --idle_timeout value          The maximum period of having received no request after which the server will shut itself down. Disabled by default. (default: 0s) [$BAZEL_REMOTE_IDLE_TIMEOUT]
@@ -67,9 +67,9 @@ GLOBAL OPTIONS:
    --s3.prefix value             The S3/minio object prefix to use when using S3 cache backend. [$BAZEL_REMOTE_S3_PREFIX]
    --s3.access_key_id value      The S3/minio access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_ACCESS_KEY_ID]
    --s3.secret_access_key value  The S3/minio secret access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
-   --s3.disable_ssl              Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL). [$BAZEL_REMOTE_S3_DISABLE_SSL]
-   --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation). [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
-   --help, -h                    show help
+   --s3.disable_ssl              Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL). (default: false) [$BAZEL_REMOTE_S3_DISABLE_SSL]
+   --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation). (default: false) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
+   --help, -h                    show help (default: false)
 ```
 
 ## Docker


### PR DESCRIPTION
If --profile_port is specified (as a positive integer), then start a
http server on that port for runtime profiling data.

The host part of the address defaults to 127.0.0.1, and can be set
with the --profile_host flag. This is needed if you want to access
the profiling URLs from bazel-remote running inside docker.

Implements #154.