### PR TITLE
refactor the cache.Cache interface

### DIFF
--- a/cache/BUILD.bazel
+++ b/cache/BUILD.bazel
@@ -5,8 +5,4 @@ go_library(
     srcs = ["cache.go"],
     importpath = "github.com/buchgr/bazel-remote/cache",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
-    ],
 )

--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -10,7 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_djherbis_atime//:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
@@ -25,6 +27,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cache:go_default_library",
+        "//cache/http:go_default_library",
         "//utils:go_default_library",
     ],
 )

--- a/cache/gcs/gcs.go
+++ b/cache/gcs/gcs.go
@@ -17,7 +17,7 @@ import (
 
 // New creates a cache that proxies requests to Google Cloud Storage.
 func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
-	diskCache cache.Cache, accessLogger cache.Logger, errorLogger cache.Logger) (cache.Cache, error) {
+	accessLogger cache.Logger, errorLogger cache.Logger) (cache.CacheProxy, error) {
 	var remoteClient *http.Client
 	var err error
 
@@ -53,5 +53,5 @@ func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
 		Path:   bucket,
 	}
 
-	return cachehttp.New(&baseURL, diskCache, remoteClient, accessLogger, errorLogger), nil
+	return cachehttp.New(&baseURL, remoteClient, accessLogger, errorLogger), nil
 }

--- a/cache/http/BUILD.bazel
+++ b/cache/http/BUILD.bazel
@@ -16,9 +16,5 @@ go_test(
     name = "go_default_test",
     srcs = ["http_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "//cache:go_default_library",
-        "//cache/disk:go_default_library",
-        "//utils:go_default_library",
-    ],
+    deps = ["//utils:go_default_library"],
 )

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",
+        "//cache/disk:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/semver:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 
 	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/cache/disk"
 )
 
 const (
@@ -29,13 +30,13 @@ var (
 )
 
 type grpcServer struct {
-	cache        cache.Cache
+	cache        *disk.DiskCache
 	accessLogger cache.Logger
 	errorLogger  cache.Logger
 }
 
 func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
-	c cache.Cache, a cache.Logger, e cache.Logger) error {
+	c *disk.DiskCache, a cache.Logger, e cache.Logger) error {
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -46,7 +47,7 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 }
 
 func ServeGRPC(l net.Listener, opts []grpc.ServerOption,
-	c cache.Cache, a cache.Logger, e cache.Logger) error {
+	c *disk.DiskCache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)
 	s := &grpcServer{cache: c, accessLogger: a, errorLogger: e}

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -43,8 +43,7 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 		return nil, err
 	}
 
-	result, _, err := cache.GetValidatedActionResult(s.cache,
-		req.ActionDigest.Hash)
+	result, _, err := s.cache.GetValidatedActionResult(req.ActionDigest.Hash)
 	if err != nil {
 		s.accessLogger.Printf("%s %s %s", errorPrefix, req.ActionDigest.Hash, err)
 		return nil, status.Error(codes.Unknown, err.Error())

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(dir)
 
-	diskCache := disk.New(dir, int64(10*maxChunkSize))
+	diskCache := disk.New(dir, int64(10*maxChunkSize), nil)
 
 	accessLogger := testutils.NewSilentLogger()
 	errorLogger := testutils.NewSilentLogger()


### PR DESCRIPTION
Since all the proxy backends use the same copy+pasted logic to use
the disk cache, refactor to put that functionality in the disk cache.
This simplifies the proxy backends.

Fixes #161.