### PR TITLE
disk cache: check that keys are the correct length

### DIFF
--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -129,7 +129,15 @@ func TestCacheEviction(t *testing.T) {
 
 	for i, thisExp := range expectedSizesNumItems {
 		strReader := strings.NewReader(strings.Repeat("a", i))
-		err := testCache.Put(cache.AC, fmt.Sprintf("aa-%d", i), int64(i), strReader)
+
+		// Suitably-sized, unique key for these testcases:
+		key := fmt.Sprintf("%0*d", sha256HashStrSize, i)
+		if len(key) != sha256.Size*2 {
+			t.Fatalf("invalid testcase- key length should be %d, not %d: %s",
+				sha256.Size*2, len(key), key)
+		}
+
+		err := testCache.Put(cache.AC, key, int64(i), strReader)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The key format is checked properly in the http and grpc server code, this
simple check should help catch incorrect internal usage (eg test cases).