### PR TITLE
disk cache: avoid panics when walking directories

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -126,6 +126,11 @@ func (c *DiskCache) migrateDirectories() error {
 func migrateDirectory(dir string) error {
 	log.Printf("Migrating files (if any) to new directory structure: %s\n", dir)
 	return filepath.Walk(dir, func(name string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Println("Error while walking directory:", err)
+			return err
+		}
+
 		if info.IsDir() {
 			if name == dir {
 				return nil
@@ -151,6 +156,11 @@ func (c *DiskCache) loadExistingFiles() error {
 	}
 	var files []NameAndInfo
 	err := filepath.Walk(c.dir, func(name string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Println("Error while walking directory:", err)
+			return err
+		}
+
 		if !info.IsDir() {
 			files = append(files, NameAndInfo{info, name})
 		}

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -46,12 +46,18 @@ func checkItems(cache *DiskCache, expSize int64, expNum int) error {
 	}
 
 	numFiles := 0
-	filepath.Walk(cache.dir, func(name string, info os.FileInfo, err error) error {
+	err := filepath.Walk(cache.dir, func(name string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			numFiles++
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	if numFiles != expNum {
 		return fmt.Errorf("expected %d files on disk, found %d", expNum, numFiles)


### PR DESCRIPTION
This pattern is used in the filepath.Walk godocs.

Discovered while investigating #67, committing separately so it doesn't
get lost in a larger PR.