### PR TITLE
http: Add support for using SHA1, MD5 or SHA256 hashes.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"crypto"
 	"io"
 )
 
@@ -43,6 +44,18 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.Text
+}
+
+// Get hash type from length of hash string
+func GetHashType(hash string) crypto.Hash {
+	if len(hash) == 32 {
+		return crypto.MD5
+	} else if len(hash) == 40 {
+		return crypto.SHA1
+	} else if len(hash) == 64 {
+		return crypto.SHA256
+	}
+	return 0
 }
 
 // Cache backends implement this interface, and are optionally used


### PR DESCRIPTION
We are working on adding caching to SCons using the bazel-remote server, for this we require support for MD5 and SHA1 hashes. Unfortunately for the s3 backend it only supports base64 encoded MD5 or SHA256 for upload hash verification so for SHA1 we have to rehash the uploaded data to generate a SHA256.

Additionally we want to avoid pulling in python protobuf dependencies into SCons, and thus it is much better for us if we can use the JSON protobuf encoding. Here I add support for that to the http server by using the "Accept:" header for a GET request and a "Content-Type" header for a PUT.

ps. sorry if my Go is not idiomatic, I am not familiar with it!