### PR TITLE
disk cache: remove oversized files at startup

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -180,10 +180,16 @@ func (c *DiskCache) loadExistingFiles() error {
 	log.Println("Building LRU index.")
 	for _, f := range files {
 		relPath := f.name[len(c.dir)+1:]
-		c.lru.Add(relPath, &lruItem{
+		ok := c.lru.Add(relPath, &lruItem{
 			size:      f.info.Size(),
 			committed: true,
 		})
+		if !ok {
+			err = os.Remove(filepath.Join(c.dir, relPath))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	log.Println("Finished loading disk cache files.")


### PR DESCRIPTION
Such files should not be uploaded in the first place, but if they are
then they will never be used and just take up space until either
manually removed (or when bazel-remote is restarted, with this change).

Discovered while investigating #176.