### PR TITLE
Update rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,10 +5,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.20.4/rules_go-v0.20.4.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.4/rules_go-v0.20.4.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.21.2/rules_go-v0.21.2.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.2/rules_go-v0.21.2.tar.gz",
     ],
-    sha256 = "5855e8ef21778be10683431a37593b120e8555c72412e9971a22c1676008aad9",
+    sha256 = "f99a9d76e972e0c8f935b2fe6d0d9d778f67c760c6d2400e23fc2e469016e2bd",
 )
 
 http_archive(


### PR DESCRIPTION
This makes bazel-remote compatible with
`--incompatible_load_proto_rules_from_bzl`.
(https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/402#732eab02-1d6f-460c-be5a-b91b2c094166)