### PR TITLE
http: Add support for receiving and sending /ac/ protobuf in JSON encoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Cache entries are set and retrieved by key, and there are two types of keys that
 Values are stored via HTTP PUT requests, and retrieved via GET requests. HEAD requests can be used to confirm
 whether a key exists or not.
 
+Values stored in the action cache are validated as an ActionResult protobuf message as per the [Bazel Remote Execution API v2](https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/execution/v2/remote_execution.proto) unless validation is disabled by configuration. The HTTP server also supports reading and writing JSON encoded protobuf ActionResult messages to the action cache by using HTTP headers `Accept: application/json` for GET requests and `Content-type: application/json` for PUT requests.
+
 ## gRPC API
 
 bazel-remote also has experimental support for the ActionCache, ContentAddressableStorage and Capabilities services in the

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//cache/disk:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/semver:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@go_googleapis//google/rpc:code_go_proto",


### PR DESCRIPTION
We are working on adding caching to SCons using the bazel-remote server, ideally we want to avoid adding the python protobuf dependencies into SCons and thus it is much better for us if we can use the JSON protobuf encoding. Here I add support for that to the http server by using the "Accept:" header for a GET request and a "Content-Type" header for a PUT.