### PR TITLE
automatically raise the limit on the number of open files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,7 +10,12 @@ gazelle(
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "rlimit_darwin.go",
+        "rlimit_unix.go",
+        "rlimit_windows.go",
+    ],
     importpath = "github.com/buchgr/bazel-remote",
     visibility = ["//visibility:private"],
     deps = [

--- a/main.go
+++ b/main.go
@@ -216,6 +216,8 @@ func main() {
 			return nil
 		}
 
+		adjustRlimit()
+
 		accessLogger := log.New(os.Stdout, "", logFlags)
 		errorLogger := log.New(os.Stderr, "", logFlags)
 

--- a/rlimit_darwin.go
+++ b/rlimit_darwin.go
@@ -1,0 +1,61 @@
+// +build darwin
+
+package main
+
+import (
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Raise the limit on the number of open files.
+func adjustRlimit() {
+	// Go 1.12 onwards uses getrlimit, which on macos does not return the
+	// correct hard limit for RLIM_NOFILE. We need to use the minimum of
+	// the max from getrlimit and the value from sysctl.
+	// Background: https://github.com/golang/go/issues/30401
+
+	var limits syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limits)
+	if err != nil {
+		log.Println("Failed to find rlimit from getrlimit:", err)
+		return
+	}
+
+	// Hack to avoid using cgo with bazel's rules_go :P
+	cmd := exec.Command("/usr/sbin/sysctl", "-n", "kern.maxfilesperproc")
+	stdout, err := cmd.Output()
+	if err != nil {
+		log.Println("Failed to find rlimit from sysctl:", err)
+		return
+	}
+
+	val := strings.Trim(string(stdout), "\n")
+	sysctlMax, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		log.Println("Failed to parse rlimit from sysctl:", err)
+		return
+	}
+
+	if limits.Max > sysctlMax {
+		limits.Max = sysctlMax
+	}
+
+	log.Printf("Initial RLIMIT_NOFILE cur: %d max: %d",
+		limits.Cur, limits.Max)
+
+	limits.Cur = limits.Max
+
+	log.Printf("Setting RLIMIT_NOFILE cur: %d max: %d",
+		limits.Cur, limits.Max)
+
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limits)
+	if err != nil {
+		log.Println("Failed to set rlimit:", err)
+		return
+	}
+
+	return
+}

--- a/rlimit_unix.go
+++ b/rlimit_unix.go
@@ -1,0 +1,35 @@
+// +build !darwin
+// +build !windows
+
+package main
+
+import (
+	"log"
+	"syscall"
+)
+
+// Raise the limit on the number of open files.
+func adjustRlimit() {
+	var limits syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &limits)
+	if err != nil {
+		log.Println("Failed to find rlimit from getrlimit:", err)
+		return
+	}
+
+	log.Printf("Initial RLIMIT_NOFILE cur: %d max: %d",
+		limits.Cur, limits.Max)
+
+	limits.Cur = limits.Max
+
+	log.Printf("Setting RLIMIT_NOFILE cur: %d max: %d",
+		limits.Cur, limits.Max)
+
+	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &limits)
+	if err != nil {
+		log.Println("Failed to set rlimit:", err)
+		return
+	}
+
+	return
+}

--- a/rlimit_windows.go
+++ b/rlimit_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package main
+
+// On unix, we need to raise the limit on the number of open files.
+// Unsure if anything is required on windows, or if bazel-remote even
+// works on windows. But let's not intentionally prevent compiling
+// for windows.
+func adjustRlimit() {
+}


### PR DESCRIPTION
bazel-remote opens a lot of files, and can easily hit the limit unless it is raised. Let's try to do that automatically.

This requires a workaround on macos, where getrlimit does not return the correct hard limit for RLIMIT_NOFILE. We need to use the minimum of the value from getrlimit and from sysctl. Since cgo is difficult with bazel's rules_go just exec the sysctl command.

Fixes #174.

You might need to take additional steps to raise the hard limit, depending on your operating system's defaults.