### PR TITLE
fix some go vet shadow warnings

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -342,11 +342,11 @@ func (c *DiskCache) Put(kind cache.EntryKind, hash string, expectedSize int64, r
 		}
 	}
 
-	if err := f.Sync(); err != nil {
+	if err = f.Sync(); err != nil {
 		return err
 	}
 
-	if err := f.Close(); err != nil {
+	if err = f.Close(); err != nil {
 		return err
 	}
 
@@ -420,12 +420,14 @@ func (c *DiskCache) Get(kind cache.EntryKind, hash string) (io.ReadCloser, int64
 
 	if available {
 		blobPath := cacheFilePath(kind, c.dir, hash)
-		fileInfo, err := os.Stat(blobPath)
+		var fileInfo os.FileInfo
+		fileInfo, err = os.Stat(blobPath)
 		if err == nil {
-			r, err := os.Open(blobPath)
+			var f *os.File
+			f, err = os.Open(blobPath)
 			if err == nil {
 				cacheHits.Inc()
-				return r, fileInfo.Size(), nil
+				return f, fileInfo.Size(), nil
 			}
 		}
 
@@ -501,7 +503,7 @@ func (c *DiskCache) Get(kind cache.EntryKind, hash string) (io.ReadCloser, int64
 		return nil, -1, err
 	}
 
-	if err := f.Close(); err != nil {
+	if err = f.Close(); err != nil {
 		return nil, -1, err
 	}
 
@@ -512,7 +514,8 @@ func (c *DiskCache) Get(kind cache.EntryKind, hash string) (io.ReadCloser, int64
 		// This flag is used by the defer() block above.
 		shouldCommit = true
 
-		f2, err := os.Open(filePath)
+		var f2 *os.File
+		f2, err = os.Open(filePath)
 		if err == nil {
 			return f2, foundSize, nil
 		}
@@ -639,7 +642,7 @@ func (c *DiskCache) GetValidatedActionResult(hash string) (*pb.ActionResult, []b
 				d.TreeDigest.SizeBytes, size)
 		}
 
-		data, err := ioutil.ReadAll(r)
+		data, err = ioutil.ReadAll(r)
 		r.Close()
 		if err != nil {
 			return nil, nil, err

--- a/cache/http/http.go
+++ b/cache/http/http.go
@@ -140,7 +140,8 @@ func (r *remoteHTTPProxyCache) Get(kind cache.EntryKind, hash string) (io.ReadCl
 	if rsp.StatusCode != http.StatusOK {
 		// If the failed http response contains some data then
 		// forward up to 1 KiB.
-		errorBytes, err := ioutil.ReadAll(io.LimitReader(rsp.Body, 1024))
+		var errorBytes []byte
+		errorBytes, err = ioutil.ReadAll(io.LimitReader(rsp.Body, 1024))
 		var errorText string
 		if err == nil {
 			errorText = string(errorBytes)

--- a/main.go
+++ b/main.go
@@ -231,7 +231,8 @@ func main() {
 			}
 		} else if c.HTTPBackend != nil {
 			httpClient := &http.Client{}
-			baseURL, err := url.Parse(c.HTTPBackend.BaseURL)
+			var baseURL *url.URL
+			baseURL, err = url.Parse(c.HTTPBackend.BaseURL)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -274,20 +275,20 @@ func main() {
 				opts := []grpc.ServerOption{}
 
 				if len(c.TLSCertFile) > 0 && len(c.TLSKeyFile) > 0 {
-					creds, err := credentials.NewServerTLSFromFile(
+					creds, err2 := credentials.NewServerTLSFromFile(
 						c.TLSCertFile, c.TLSKeyFile)
-					if err != nil {
-						log.Fatal(err)
+					if err2 != nil {
+						log.Fatal(err2)
 					}
 					opts = append(opts, grpc.Creds(creds))
 				}
 
 				log.Printf("Starting gRPC server on address %s", addr)
 
-				err = server.ListenAndServeGRPC(addr, opts,
+				err3 := server.ListenAndServeGRPC(addr, opts,
 					diskCache, accessLogger, errorLogger)
-				if err != nil {
-					log.Fatal(err)
+				if err3 != nil {
+					log.Fatal(err3)
 				}
 			}()
 		}

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -242,9 +242,9 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 			req, err := srv.Recv()
 			if err == io.EOF {
 				if resp.CommittedSize != size {
-					err := fmt.Errorf("Unexpected amount of data read: %d expected: %d",
+					msg := fmt.Sprintf("Unexpected amount of data read: %d expected: %d",
 						resp.CommittedSize, size)
-					recvResult <- status.Error(codes.Unknown, err.Error())
+					recvResult <- status.Error(codes.Unknown, msg)
 					return
 				}
 

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -73,12 +73,12 @@ func TestMain(m *testing.M) {
 	listener = bufconn.Listen(bufSize)
 
 	go func() {
-		err := ServeGRPC(
+		err2 := ServeGRPC(
 			listener,
 			[]grpc.ServerOption{},
 			diskCache, accessLogger, errorLogger)
-		if err != nil {
-			fmt.Println(err)
+		if err2 != nil {
+			fmt.Println(err2)
 			os.Exit(1)
 		}
 	}()
@@ -157,7 +157,7 @@ func TestGrpcAc(t *testing.T) {
 
 	for _, tc := range badDigestTestCases {
 		r := pb.GetActionResultRequest{ActionDigest: &tc.digest}
-		_, err := acClient.GetActionResult(ctx, &r)
+		_, err = acClient.GetActionResult(ctx, &r)
 		checkBadDigestErr(t, err, tc)
 	}
 
@@ -191,7 +191,7 @@ func TestGrpcAc(t *testing.T) {
 
 	for _, tc := range badDigestTestCases {
 		r := pb.UpdateActionResultRequest{ActionDigest: &tc.digest}
-		_, err := acClient.UpdateActionResult(ctx, &r)
+		_, err = acClient.UpdateActionResult(ctx, &r)
 		checkBadDigestErr(t, err, tc)
 	}
 


### PR DESCRIPTION
To see the warnings:
go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
go vet -vettool=$(which shadow) ./...

The shadow checker is considered "experimental", and some projects find it noisy. So I don't think we should add such a check to the bazelci presubmit setup for now.