### PR TITLE
return an error if there was one

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -432,7 +432,7 @@ func (c *DiskCache) Get(kind cache.EntryKind, hash string) (io.ReadCloser, int64
 		}
 
 		cacheMisses.Inc()
-		return nil, -1, nil
+		return nil, -1, err
 	}
 
 	cacheMisses.Inc()


### PR DESCRIPTION
I spotted this when fixing some shadowing warnings. If there was a file-related error when handling a disk cache hit then we were returning a cache miss instead of an error. I think we should return the error so it can (potentially) be noticed and fixed.