### PR TITLE
Support IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ GLOBAL OPTIONS:
    --s3.access_key_id value      The S3/minio access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_ACCESS_KEY_ID]
    --s3.secret_access_key value  The S3/minio secret access key to use when using S3 cache backend. [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
    --s3.disable_ssl              Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL). (default: false) [$BAZEL_REMOTE_S3_DISABLE_SSL]
+   --s3.iam_role_endpoint        Endpoint for using IAM security credentials, eg http://169.254.169.254 for EC2, http://169.254.170.2 for ECS. [$BAZEL_REMOTE_IAM_ROLE_ENDPOINT]
+   --s3.region                   The AWS region. Required when using s3.iam_role_endpoint. [$BAZEL_REMOTE_S3_REGION]
    --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation). (default: false) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
    --help, -h                    show help (default: false)
 ```
@@ -129,6 +131,10 @@ host: localhost
 #  access_key_id: EXAMPLE_ACCESS_KEY
 #  secret_access_key: EXAMPLE_SECRET_KEY
 #  disable_ssl: true
+#
+# Provide either iam_role_endpoint/region or access_key_id/secret_access_key
+#  iam_role_endpoint: http://169.254.169.254
+#  region: us-east-1
 #
 #http_proxy:
 #  url: https://remote-cache.com:8080/cache

--- a/cache/s3/BUILD.bazel
+++ b/cache/s3/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//cache:go_default_library",
         "//config:go_default_library",
         "@com_github_minio_minio_go_v6//:go_default_library",
+        "@com_github_minio_minio_go_v6//pkg/credentials:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,8 @@ type S3CloudStorageConfig struct {
 	AccessKeyID     string `yaml:"access_key_id"`
 	SecretAccessKey string `yaml:"secret_access_key"`
 	DisableSSL      bool   `yaml:"disable_ssl"`
+	IAMRoleEndpoint string `yaml:"iam_role_endpoint"`
+	Region          string `yaml:"region"`
 }
 
 type GoogleCloudStorageConfig struct {
@@ -145,5 +147,12 @@ func validateConfig(c *Config) error {
 			return errors.New("The 'url' field is required for 'http_proxy'")
 		}
 	}
+
+	if c.S3CloudStorage != nil {
+		if c.S3CloudStorage.AccessKeyID != "" && c.S3CloudStorage.IAMRoleEndpoint != "" {
+			return errors.New("Expected either 's3.access_key_id' or 's3.iam_role_endpoint', found both")
+		}
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -168,6 +168,18 @@ func main() {
 			Usage:   "Whether to disable TLS/SSL when using the S3 cache backend.  Default is false (enable TLS/SSL).",
 			EnvVars: []string{"BAZEL_REMOTE_S3_DISABLE_SSL"},
 		},
+		&cli.StringFlag{
+			Name:    "s3.iam_role_endpoint",
+			Value:   "",
+			Usage:   "Endpoint for using IAM security credentials, eg http://169.254.169.254 for EC2, http://169.254.170.2 for ECS",
+			EnvVars: []string{"BAZEL_REMOTE_S3_IAM_ROLE_ENDPOINT"},
+		},
+		&cli.StringFlag{
+			Name:    "s3.region",
+			Value:   "",
+			Usage:   "The AWS region. Required when using s3.iam_role_endpoint",
+			EnvVars: []string{"BAZEL_REMOTE_S3_REGION"},
+		},
 		&cli.BoolFlag{
 			Name:    "disable_http_ac_validation",
 			Usage:   "Whether to disable ActionResult validation for HTTP requests.  Default is false (enable validation).",
@@ -191,6 +203,8 @@ func main() {
 					AccessKeyID:     ctx.String("s3.access_key_id"),
 					SecretAccessKey: ctx.String("s3.secret_access_key"),
 					DisableSSL:      ctx.Bool("s3.disable_ssl"),
+					IAMRoleEndpoint: ctx.String("s3.iam_role_endpoint"),
+					Region:          ctx.String("s3.region"),
 				}
 			}
 			c, err = config.New(


### PR DESCRIPTION
Adds support for pulling AWS credentials from instance metadata.

Resolves [#172 ](https://github.com/buchgr/bazel-remote/issues/172)