### PR TITLE
disk.go: Return the correct data for action result

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -607,13 +607,13 @@ func (c *DiskCache) GetValidatedActionResult(hash string) (*pb.ActionResult, []b
 		return nil, nil, nil // aka "not found"
 	}
 
-	data, err := ioutil.ReadAll(rdr)
+	acdata, err := ioutil.ReadAll(rdr)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	result := &pb.ActionResult{}
-	err = proto.Unmarshal(data, result)
+	err = proto.Unmarshal(acdata, result)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -642,14 +642,14 @@ func (c *DiskCache) GetValidatedActionResult(hash string) (*pb.ActionResult, []b
 				d.TreeDigest.SizeBytes, size)
 		}
 
-		data, err = ioutil.ReadAll(r)
+		oddata, err = ioutil.ReadAll(r)
 		r.Close()
 		if err != nil {
 			return nil, nil, err
 		}
 
 		tree := pb.Tree{}
-		err = proto.Unmarshal(data, &tree)
+		err = proto.Unmarshal(oddata, &tree)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -691,5 +691,5 @@ func (c *DiskCache) GetValidatedActionResult(hash string) (*pb.ActionResult, []b
 		}
 	}
 
-	return result, data, nil
+	return result, acdata, nil
 }


### PR DESCRIPTION
The code accidentally overwrote the contents of the outer `data` variable (containing a serialized ActionResult protobuf) with the bytes from the last Tree protobuf processed from the ActionResult's OutputDirectories.

The server then returned the Tree protobuf to Bazel via the `return` in the last line. However, Bazel was expecting the `ActionResult` protobuf of course. This caused the weirdest things to happen, most notably builds mysteriously failing due to output files not existing or Bazel complaining that some file names are not valid UTF-8.

This was an accidental regression introduced by https://github.com/buchgr/bazel-remote/commit/b2e2f705f43d20e12dd8139f1719e7bd9c40a9b2.