### PR TITLE
re-add http proxy tests that were lost in the cache.Cache refactor

### DIFF
--- a/cache/http/BUILD.bazel
+++ b/cache/http/BUILD.bazel
@@ -16,5 +16,9 @@ go_test(
     name = "go_default_test",
     srcs = ["http_test.go"],
     embed = [":go_default_library"],
-    deps = ["//utils:go_default_library"],
+    deps = [
+        "//cache:go_default_library",
+        "//cache/disk:go_default_library",
+        "//utils:go_default_library",
+    ],
 )


### PR DESCRIPTION
Confirm that we can fill the proxy backend via the disk cache, and vice versa. Followup to #162.