### PR TITLE
Fix files being uploaded to a unaccessible location when not using a prefix

### DIFF
--- a/cache/s3/s3.go
+++ b/cache/s3/s3.go
@@ -109,6 +109,9 @@ func New(s3Config *config.S3CloudStorageConfig, accessLogger cache.Logger,
 }
 
 func (c *s3Cache) objectKey(hash string, kind cache.EntryKind) string {
+	if c.prefix == "" {
+		return fmt.Sprintf("%s/%s", kind, hash)
+	}
 	return fmt.Sprintf("%s/%s/%s", c.prefix, kind, hash)
 }
 


### PR DESCRIPTION
Previously when using S3/S3-compatible storage as the caching backend,
if the prefix is empty, the object key would begin with two slashes
which makes the object unaccessible.
