### PR TITLE
Add ARM64 build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,10 +46,21 @@ go_binary(
 go_image(
     name = "bazel-remote-base",
     embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
     pure = "on",
     static = "on",
+    visibility = ["//visibility:private"],
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+)
+
+go_image(
+    name = "bazel-remote-base-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
     goos = "linux",
-    goarch = "amd64",
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:private"],
     x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
 )
@@ -60,6 +71,25 @@ container_image(
     cmd = ["--max_size=5"],
     entrypoint = [
         "/app/bazel-remote-base.binary",
+        "--port=8080",
+        "--dir=/data",
+
+        # Listen on all addresses, not just 127.0.0.1, so this can
+        # be reached from outside the container (with a -p mapping).
+        "--profile_host=",
+        # Specify a port to enable the profiling http server.
+        "--profile_port=6060",
+    ],
+    ports = ["8080"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "bazel-remote-image-arm64",
+    base = ":bazel-remote-base-arm64",
+    cmd = ["--max_size=1"],
+    entrypoint = [
+        "/app/bazel-remote-base-arm64.binary",
         "--port=8080",
         "--dir=/data",
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@
 # Build container
 FROM golang:1.14 AS builder
 
+# overwrite GOARCH with --build-arg GOARCH=arm64 when invoking docker build
+ARG GOARCH="amd64"
+
 WORKDIR /src
 COPY . .
 RUN ./linux-build.sh

--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ The below command will build a docker image from source and install it into your
 $ bazel run :bazel-remote-image
 ```
 
+### ARM Support
+
+Bazel remote cache server can be run on an ARM architecture (i.e.: on a Raspberry Pi).
+
+To build for ARM, use:
+
+```bash
+$ bazel run :bazel-remote-image-arm64
+```
+
 ## Build a standalone Linux binary
 
 ```bash

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -2,7 +2,9 @@
 
 set -euxo pipefail
 
+GOARCH=${GOARCH:-amd64}
+
 VERSION_TAG="$(git rev-parse HEAD)"
 VERSION_LINK_FLAG="main.gitCommit=${VERSION_TAG}"
 
-CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-extldflags '-static' -X ${VERSION_LINK_FLAG}" .
+CGO_ENABLED=0 GOOS=linux GOARCH=$GOARCH go build -a -ldflags "-extldflags '-static' -X ${VERSION_LINK_FLAG}" .


### PR DESCRIPTION
Successfully deployed a remote cache server onto a Rasberry Pi3 B+, built [abseil](https://github.com/abseil/abseil-cpp) using it..

Config:
* building `abseil` from source [9ee91d3e430fb33a4590486573792eb0fa146c2d](https://github.com/abseil/abseil-cpp/commit/9ee91d3e430fb33a4590486573792eb0fa146c2d).
* server: Raspi 3B+, 18.04.3 LTS (Bionic Beaver), 64-bit.
* client: bazel 2.1.1 on 18.04.3 LTS (Bionic Beaver), 64-bit.

server invocation:
```bash
➜  git ./bazel-remote --dir=/home/mihai/bazel_cache --max_size=1
2020/02/28 16:22:18 bazel-remote built with go1.12 from git commit 6e53409ee369902cd91d0a54dedc1c754d65669a.
2020/02/28 16:22:18 Initial RLIMIT_NOFILE cur: 1024 max: 1048576
2020/02/28 16:22:18 Setting RLIMIT_NOFILE cur: 1048576 max: 1048576
2020/02/28 16:22:18 Migrating files (if any) to new directory structure: /home/mihai/bazel_cache/ac
2020/02/28 16:22:18 Migrating files (if any) to new directory structure: /home/mihai/bazel_cache/cas
2020/02/28 16:22:18 Loading existing files in /home/mihai/bazel_cache.
2020/02/28 16:22:19 Sorting cache files by atime.
2020/02/28 16:22:19 Building LRU index.
2020/02/28 16:22:19 Finished loading disk cache files.
2020/02/28 16:22:19 Loaded 2811 existing disk cache items.
2020/02/28 16:22:19 Starting HTTP server on address :8080
2020/02/28 16:22:19 Starting gRPC server on address :9092
```

client invocation:
```bash
➜  abseil-cpp git:(master) bazel build --remote_cache=http://192.168.0.105:8080 //...
Starting local Bazel server and connecting to it...
WARNING: ignoring LD_PRELOAD in environment.
INFO: Invocation ID: 3306a2d1-b198-4771-93d5-f31174b1e65a
INFO: Analyzed 307 targets (39 packages loaded, 1785 targets configured).
INFO: Found 307 targets...
INFO: From Compiling absl/debugging/symbolize_test.cc:
/tmp/cc73YuF7.s: Assembler messages:
/tmp/cc73YuF7.s:1662: Warning: ignoring changed section attributes for .text
INFO: Elapsed time: 416.228s, Critical Path: 43.28s
INFO: 625 processes: 625 linux-sandbox.
INFO: Build completed successfully, 1338 total actions

➜  abseil-cpp git:(master) bazel clean --async  
INFO: Starting clean.
INFO: Output tree moved to /home/mihai/.cache/bazel/_bazel_mihai/1a6d90d837a4cb016e894dc6dfa0b87f/execroot_tmp_30632 for deletion

➜  abseil-cpp git:(master) bazel build --remote_cache=http://192.168.0.105:8080 //...
INFO: Invocation ID: d6782cbd-b2c4-4a19-aed6-1976f43ae77a
INFO: Analyzed 307 targets (39 packages loaded, 1785 targets configured).
INFO: Found 307 targets...
INFO: From Compiling absl/debugging/symbolize_test.cc:
/tmp/cc73YuF7.s: Assembler messages:
/tmp/cc73YuF7.s:1662: Warning: ignoring changed section attributes for .text
INFO: Elapsed time: 172.386s, Critical Path: 27.05s
INFO: 625 processes: 625 remote cache hit.
INFO: Build completed successfully, 1338 total actions
```