### PR TITLE
Run Buildifier as part of presubmit checks

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,8 @@
 ---
 validate_config: 1
+buildifier:
+  version: latest
+  warnings: "all"
 tasks:
   ubuntu1604:
     platform: ubuntu1604

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_push")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 gazelle(
     name = "gazelle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,13 +118,6 @@ go_repository(
 
 go_repository(
     # minio has this dependency
-    name = "org_golang_x_net",
-    commit = "c39426892332e1bb5ec0a434a079bf82f5d30c54",
-    importpath = "golang_org/x/net",
-)
-
-go_repository(
-    # minio has this dependency
     name = "org_golang_x_sys",
     importpath = "golang.org/x/sys",
     sum = "h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=",
@@ -144,12 +137,6 @@ go_repository(
     importpath = "golang.org/x/crypto",
     sum = "h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=",
     version = "v0.0.0-20200221231518-2aa609cf4a9d",
-)
-
-go_repository(
-    name = "org_golang_x_net",
-    commit = "1e491301e022f8f977054da4c2d852decd59571f",
-    importpath = "golang.org/x/net",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,26 +1,24 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    sha256 = "e6a6c016b0663e06fa5fccf1cd8152eab8aa8180c583ec20c872f4f9953a7ac5",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.22.1/rules_go-v0.22.1.tar.gz",
     ],
-    sha256 = "e6a6c016b0663e06fa5fccf1cd8152eab8aa8180c583ec20c872f4f9953a7ac5",
 )
 
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
-    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 


### PR DESCRIPTION
This ensures that all Starlark files (`BUILD`, `WORKSPACE`, `*.bzl`) are formatted and pass lint checks (e.g. for incompatible changes).