### PR TITLE
fix some ineffectual assignments

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -325,7 +325,7 @@ func (c *DiskCache) Put(kind cache.EntryKind, hash string, expectedSize int64, r
 		f.Close()
 	}()
 
-	var bytesCopied int64 = 0
+	var bytesCopied int64
 	if kind == cache.CAS {
 		hasher := sha256.New()
 		if bytesCopied, err = io.Copy(io.MultiWriter(f, hasher), r); err != nil {

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -84,7 +84,7 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Non-existing item
-	rdr, sizeBytes, err := testCache.Get(cache.CAS, CONTENTS_HASH)
+	rdr, _, err := testCache.Get(cache.CAS, CONTENTS_HASH)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Get the item back
-	rdr, sizeBytes, err = testCache.Get(cache.CAS, CONTENTS_HASH)
+	rdr, sizeBytes, err := testCache.Get(cache.CAS, CONTENTS_HASH)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/disk/lru.go
+++ b/cache/disk/lru.go
@@ -59,7 +59,7 @@ func (c *sizedLRU) Add(key Key, value SizedItem) (ok bool) {
 		return false
 	}
 
-	sizeDelta := int64(0)
+	var sizeDelta int64
 	if ee, ok := c.cache[key]; ok {
 		c.ll.MoveToFront(ee)
 		sizeDelta = value.Size() - ee.Value.(*entry).value.Size()

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -216,6 +216,9 @@ func TestGrpcAc(t *testing.T) {
 	if proto.Equal(&zeroReq, zeroResp) {
 		t.Fatal("expected non-zero ActionResult to be returned")
 	}
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// We expect the returned metadata to have changed.
 	if zeroResp.ExecutionMetadata == nil {
@@ -534,6 +537,9 @@ func TestGrpcByteStream(t *testing.T) {
 				"instance", tc.digest.Hash),
 		}
 		rc, err := bsClient.Read(ctx, &r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, err = rc.Recv()
 		checkBadDigestErr(t, err, tc)
 	}
@@ -551,6 +557,9 @@ func TestGrpcByteStream(t *testing.T) {
 			Data:        blobPart,
 		}
 		err = wc.Send(&r)
+		if err != nil {
+			t.Fatal(err)
+		}
 		_, err = wc.CloseAndRecv()
 		checkBadDigestErr(t, err, tc)
 	}


### PR DESCRIPTION
* Prefer "var ..." style declarations for zero values.
* Use the blank identifier when the value won't be used before being
  overwritten.
* Check some intermediate error values in tests.