### PR TITLE
unexport server.ServeGRPC

### DIFF
--- a/server/grpc.go
+++ b/server/grpc.go
@@ -43,10 +43,10 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 		return err
 	}
 
-	return ServeGRPC(listener, opts, c, a, e)
+	return serveGRPC(listener, opts, c, a, e)
 }
 
-func ServeGRPC(l net.Listener, opts []grpc.ServerOption,
+func serveGRPC(l net.Listener, opts []grpc.ServerOption,
 	c *disk.DiskCache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -73,7 +73,7 @@ func TestMain(m *testing.M) {
 	listener = bufconn.Listen(bufSize)
 
 	go func() {
-		err2 := ServeGRPC(
+		err2 := serveGRPC(
 			listener,
 			[]grpc.ServerOption{},
 			diskCache, accessLogger, errorLogger)


### PR DESCRIPTION
This function is only used internally by the server package, and does not need to be exported.