### PR TITLE
use a valid hash in TestCachePutWrongSize

### DIFF
--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -163,9 +163,23 @@ func TestCachePutWrongSize(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 	testCache := New(cacheDir, 100, nil)
 
-	err := testCache.Put(cache.AC, "aa-aa", int64(10), strings.NewReader("hello"))
+	content := "hello"
+	hash := hashStr(content)
+
+	var err error
+
+	err = testCache.Put(cache.AC, hash, int64(len(content)), strings.NewReader(content))
+	if err != nil {
+		t.Fatal("Expected success", err)
+	}
+
+	err = testCache.Put(cache.AC, hash, int64(len(content))+1, strings.NewReader(content))
 	if err == nil {
-		t.Fatal("Expected error due to size being different")
+		t.Error("Expected error due to size being different")
+	}
+	err = testCache.Put(cache.AC, hash, int64(len(content))-1, strings.NewReader(content))
+	if err == nil {
+		t.Error("Expected error due to size being different")
 	}
 }
 


### PR DESCRIPTION
This test intends to check that a mismatching size causes Put to fail, but it also used an invalid hash. In which case it is not certain which condition caused the error. We should instead use only a single incorrect parameter in this test.