### PR TITLE
add a flag to disable gRPC GetActionResult dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ GLOBAL OPTIONS:
    --s3.iam_role_endpoint value  Endpoint for using IAM security credentials, eg http://169.254.169.254 for EC2, http://169.254.170.2 for ECS. [$BAZEL_REMOTE_S3_IAM_ROLE_ENDPOINT]
    --s3.region value             The AWS region. Required when using s3.iam_role_endpoint. [$BAZEL_REMOTE_S3_REGION]
    --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests. (default: false, ie enable validation) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
+   --disable_grpc_ac_deps_check  Whether to disable ActionResult dependency check for gRPC GetActionResult requests. (default: false, ie enable ActionCache dependency checks) [$BAZEL_REMOTE_DISABLE_GRPS_AC_DEPS_CHECK]
    --help, -h                    show help (default: false)
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -48,13 +48,15 @@ type Config struct {
 	HTTPBackend             *HTTPBackendConfig        `yaml:"http_proxy"`
 	IdleTimeout             time.Duration             `yaml:"idle_timeout"`
 	DisableHTTPACValidation bool                      `yaml:"disable_http_ac_validation"`
+	DisableGRPCACDepsCheck  bool                      `yaml:"disable_grpc_ac_deps_check"`
 }
 
 // New ...
 func New(dir string, maxSize int, host string, port int, grpc_port int,
 	profile_host string, profile_port int, htpasswdFile string,
 	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration,
-	s3 *S3CloudStorageConfig, disable_http_ac_validation bool) (*Config, error) {
+	s3 *S3CloudStorageConfig, disable_http_ac_validation bool,
+	disable_grpc_ac_deps_check bool) (*Config, error) {
 	c := Config{
 		Host:                    host,
 		Port:                    port,
@@ -71,6 +73,7 @@ func New(dir string, maxSize int, host string, port int, grpc_port int,
 		HTTPBackend:             nil,
 		IdleTimeout:             idleTimeout,
 		DisableHTTPACValidation: disable_http_ac_validation,
+		DisableGRPCACDepsCheck:  disable_grpc_ac_deps_check,
 	}
 
 	err := validateConfig(&c)

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -33,9 +33,11 @@ type grpcServer struct {
 	cache        *disk.DiskCache
 	accessLogger cache.Logger
 	errorLogger  cache.Logger
+	depsCheck    bool
 }
 
 func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
+	validateACDeps bool,
 	c *disk.DiskCache, a cache.Logger, e cache.Logger) error {
 
 	listener, err := net.Listen("tcp", addr)
@@ -43,14 +45,18 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 		return err
 	}
 
-	return serveGRPC(listener, opts, c, a, e)
+	return serveGRPC(listener, opts, validateACDeps, c, a, e)
 }
 
 func serveGRPC(l net.Listener, opts []grpc.ServerOption,
+	validateACDepsCheck bool,
 	c *disk.DiskCache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)
-	s := &grpcServer{cache: c, accessLogger: a, errorLogger: e}
+	s := &grpcServer{
+		cache: c, accessLogger: a, errorLogger: e,
+		depsCheck: validateACDepsCheck,
+	}
 	pb.RegisterActionCacheServer(srv, s)
 	pb.RegisterCapabilitiesServer(srv, s)
 	pb.RegisterContentAddressableStorageServer(srv, s)

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -72,10 +72,13 @@ func TestMain(m *testing.M) {
 
 	listener = bufconn.Listen(bufSize)
 
+	validateAC := true
+
 	go func() {
 		err2 := serveGRPC(
 			listener,
 			[]grpc.ServerOption{},
+			validateAC,
 			diskCache, accessLogger, errorLogger)
 		if err2 != nil {
 			fmt.Println(err2)


### PR DESCRIPTION
It is possible for bazel-remote to be used as a sharded backing store for other bazel caches, using HTTP with the `--disable_http_ac_validation` flag. In this scenario, CAS blobs that the ActionResult refers to may only be stored on another shard.

This patch allows similar functionality for gRPC with the new `--disable_grpc_ac_deps_check` flag. Unlike with HTTP, gRPC GetActionResult requests are are still checked to confirm that the result is a valid ActionResult message.

Implements #231.