### PR TITLE
grpc: implement basic idle timeout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,6 @@ and the corresponding parts of the [Byte Stream API](https://github.com/googleap
 
 To query endpoint metrics see [github.com/grpc-ecosystem/go-grpc-prometheus's metrics documentation](https://github.com/grpc-ecosystem/go-grpc-prometheus#metrics).
 
-### Limitations
-
-- The gRPC backend does not currently work with the `--idle_timeout` flag,
-  only HTTP requests update the idle timer.
-
 ## Usage
 
 If a YAML configuration file is specified by the `--config_file` command line

--- a/main.go
+++ b/main.go
@@ -325,6 +325,12 @@ func main() {
 					unaryInterceptors = append(unaryInterceptors, gba.UnaryServerInterceptor)
 				}
 
+				if idleTimer != nil {
+					it := server.NewGrpcIdleTimer(idleTimer)
+					streamInterceptors = append(streamInterceptors, it.StreamServerInterceptor)
+					unaryInterceptors = append(unaryInterceptors, it.UnaryServerInterceptor)
+				}
+
 				opts = append(opts, grpc.ChainStreamInterceptor(streamInterceptors...))
 				opts = append(opts, grpc.ChainUnaryInterceptor(unaryInterceptors...))
 

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "grpc_basic_auth.go",
         "grpc_bytestream.go",
         "grpc_cas.go",
+        "grpc_idle_timeout.go",
         "http.go",
     ],
     importpath = "github.com/buchgr/bazel-remote/server",
@@ -15,6 +16,7 @@ go_library(
     deps = [
         "//cache:go_default_library",
         "//cache/disk:go_default_library",
+        "//utils/idle:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/semver:go_default_library",

--- a/server/grpc_idle_timeout.go
+++ b/server/grpc_idle_timeout.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/buchgr/bazel-remote/utils/idle"
+)
+
+type GrpcIdleTimer struct {
+	idleTimer *idle.IdleTimer
+}
+
+func NewGrpcIdleTimer(idleTimer *idle.IdleTimer) *GrpcIdleTimer {
+	return &GrpcIdleTimer{idleTimer: idleTimer}
+}
+
+func (t *GrpcIdleTimer) StreamServerInterceptor(srv interface{},
+	ss grpc.ServerStream, info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler) error {
+
+	t.idleTimer.ResetTimer()
+	return handler(srv, ss)
+}
+
+func (t *GrpcIdleTimer) UnaryServerInterceptor(ctx context.Context,
+	req interface{}, info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler) (interface{}, error) {
+
+	t.idleTimer.ResetTimer()
+	return handler(ctx, req)
+}


### PR DESCRIPTION
This might not work well for bytestreaming large files since we only reset the timer once at the start of each request. But maybe this is good enough, we'll see.