### PR TITLE
test: remove redundant CreateTmpCacheDirs helper

### DIFF
--- a/server/http_test.go
+++ b/server/http_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDownloadFile(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	blobSize := int64(1024)
@@ -83,7 +83,7 @@ func TestDownloadFile(t *testing.T) {
 }
 
 func TestUploadFilesConcurrently(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	const NumUploads = 1000
@@ -149,7 +149,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 }
 
 func TestUploadSameFileConcurrently(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	data, hash := testutils.RandomDataAndHash(1024)
@@ -189,7 +189,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 }
 
 func TestUploadCorruptedFile(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	data, hash := testutils.RandomDataAndHash(1024)
@@ -230,7 +230,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 }
 
 func TestUploadEmptyActionResult(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	data, hash := testutils.RandomDataAndHash(0)
@@ -282,7 +282,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 }
 
 func TestStatusPage(t *testing.T) {
-	cacheDir := testutils.CreateTmpCacheDirs(t)
+	cacheDir := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir)
 
 	r, err := http.NewRequest("GET", "/status", bytes.NewReader([]byte{}))

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -43,15 +43,6 @@ func RandomDataAndHash(size int64) ([]byte, string) {
 	return data, hashStr
 }
 
-func CreateTmpCacheDirs(t *testing.T) string {
-	path, err := ioutil.TempDir("", "bazel-remote-test")
-	if err != nil {
-		t.Error("Couldn't create tmp dir", err)
-	}
-	os.MkdirAll(path, os.ModePerm)
-	return path
-}
-
 // NewSilentLogger returns a cheap logger that doesn't print anything, useful
 // for tests.
 func NewSilentLogger() *log.Logger {


### PR DESCRIPTION
utils.CreateTmpCacheDirs is identical to utils.TempDir except it performed a no-op os.MkdirAll call, called t.Error instead of t.Fatal, and used a slightly different tempdir pattern string.