### PR TITLE
reject positional cmdline args

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,6 +243,18 @@ func main() {
 			return nil
 		}
 
+		if ctx.NArg() > 0 {
+			fmt.Fprintf(ctx.App.Writer,
+				"Error: bazel-remote does not take positional aguments\n")
+			for i := 0; i < ctx.NArg(); i++ {
+				fmt.Fprintf(ctx.App.Writer, "arg: %s\n", ctx.Args().Get(i))
+			}
+			fmt.Fprintf(ctx.App.Writer, "\n")
+
+			cli.ShowAppHelp(ctx)
+			return nil
+		}
+
 		adjustRlimit()
 
 		accessLogger := log.New(os.Stdout, "", logFlags)

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(ctx.App.Writer, "%v\n\n", err)
 			cli.ShowAppHelp(ctx)
-			return nil
+			return cli.Exit("", 1)
 		}
 
 		if ctx.NArg() > 0 {
@@ -252,7 +252,7 @@ func main() {
 			fmt.Fprintf(ctx.App.Writer, "\n")
 
 			cli.ShowAppHelp(ctx)
-			return nil
+			return cli.Exit("", 1)
 		}
 
 		adjustRlimit()


### PR DESCRIPTION
bazel-remote doesn't use positional commandline args, it should exit with an error code if they are given.