### PR TITLE
Fix big cardinality issue on HTTP metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,16 +283,19 @@ func main() {
 
 		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache)
 
+		metricsMdlw := httpmiddleware.New(httpmiddleware.Config{
+			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{}),
+		})
 		mux := http.NewServeMux()
 		httpServer := &http.Server{
 			Addr:    c.Host + ":" + strconv.Itoa(c.Port),
-			Handler: wrapMetricsHandler(mux),
+			Handler: mux,
 		}
 
 		validateAC := !c.DisableHTTPACValidation
 		h := server.NewHTTPCache(diskCache, accessLogger, errorLogger, validateAC, gitCommit)
-		mux.Handle("/metrics", promhttp.Handler())
-		mux.HandleFunc("/status", h.StatusPageHandler)
+		mux.Handle("/metrics", metricsMdlw.Handler("metrics", promhttp.Handler()))
+		mux.Handle("/status", metricsMdlw.Handler("status", http.HandlerFunc(h.StatusPageHandler)))
 
 		var htpasswdSecrets auth.SecretProvider
 		cacheHandler := h.CacheHandler
@@ -307,7 +310,9 @@ func main() {
 			cacheHandler = wrapIdleHandler(cacheHandler, idleTimer, accessLogger, httpServer)
 		}
 
-		mux.HandleFunc("/", cacheHandler)
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			metricsMdlw.Handler(r.Method, http.HandlerFunc(cacheHandler)).ServeHTTP(w, r)
+		})
 
 		if c.GRPCPort > 0 {
 
@@ -422,11 +427,4 @@ func wrapIdleHandler(handler http.HandlerFunc, idleTimer *idle.Timer, accessLogg
 func wrapAuthHandler(handler http.HandlerFunc, secrets auth.SecretProvider, host string) http.HandlerFunc {
 	authenticator := auth.NewBasicAuthenticator(host, secrets)
 	return auth.JustCheck(authenticator, handler)
-}
-
-func wrapMetricsHandler(handler http.Handler) http.Handler {
-	mdlw := httpmiddleware.New(httpmiddleware.Config{
-		Recorder: httpmetrics.NewRecorder(httpmetrics.Config{}),
-	})
-	return mdlw.Handler("", handler)
 }

--- a/main.go
+++ b/main.go
@@ -283,9 +283,6 @@ func main() {
 
 		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache)
 
-		metricsMdlw := httpmiddleware.New(httpmiddleware.Config{
-			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{}),
-		})
 		mux := http.NewServeMux()
 		httpServer := &http.Server{
 			Addr:    c.Host + ":" + strconv.Itoa(c.Port),
@@ -294,6 +291,9 @@ func main() {
 
 		validateAC := !c.DisableHTTPACValidation
 		h := server.NewHTTPCache(diskCache, accessLogger, errorLogger, validateAC, gitCommit)
+		metricsMdlw := httpmiddleware.New(httpmiddleware.Config{
+			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{}),
+		})
 		mux.Handle("/metrics", metricsMdlw.Handler("metrics", promhttp.Handler()))
 		mux.Handle("/status", metricsMdlw.Handler("status", http.HandlerFunc(h.StatusPageHandler)))
 


### PR DESCRIPTION
@buchgr We have noticed that Prometheus has issues to keep up with high cardinality load for HTTP metrics (the scraping times out). This PR keeps cardinality low by using the HTTP method as handler ID (instead of the blob SHAs).
For more, see https://github.com/slok/go-http-metrics#custom-handler-id
