### PR TITLE
Add flag for enabling metrics and use bigger duration buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ GLOBAL OPTIONS:
    --s3.region value             The AWS region. Required when using s3.iam_role_endpoint. [$BAZEL_REMOTE_S3_REGION]
    --disable_http_ac_validation  Whether to disable ActionResult validation for HTTP requests. (default: false, ie enable validation) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
    --disable_grpc_ac_deps_check  Whether to disable ActionResult dependency check for gRPC GetActionResult requests. (default: false, ie enable ActionCache dependency checks) [$BAZEL_REMOTE_DISABLE_GRPS_AC_DEPS_CHECK]
+   --enable_endpoint_metrics     Whether to enable metrics for each HTTP/gRPC endpoint. (default: false, ie disable metrics) [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]
    --help, -h                    show help (default: false)
 ```
 
@@ -133,6 +134,9 @@ host: localhost
 # If set to true, do not check that CAS items referred
 # to by ActionResult messages are in the cache.
 #disable_grpc_ac_deps_check: false
+
+# If set to true, enable metrics for each HTTP/gRPC endpoint.
+#enable_endpoint_metrics: false
 
 # At most one of the proxy backends can be selected:
 #

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	IdleTimeout             time.Duration             `yaml:"idle_timeout"`
 	DisableHTTPACValidation bool                      `yaml:"disable_http_ac_validation"`
 	DisableGRPCACDepsCheck  bool                      `yaml:"disable_grpc_ac_deps_check"`
+	EnableEndpointMetrics   bool                      `yaml:"enable_endpoint_metrics"`
 }
 
 // New returns a validated Config with the specified values, and an error
@@ -60,7 +61,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 	profileHost string, profilePort int, htpasswdFile string,
 	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration,
 	s3 *S3CloudStorageConfig, disableHTTPACValidation bool,
-	disableGRPCACDepsCheck bool) (*Config, error) {
+	disableGRPCACDepsCheck bool, enableEndpointMetrics bool) (*Config, error) {
 	c := Config{
 		Host:                    host,
 		Port:                    port,
@@ -78,6 +79,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 		IdleTimeout:             idleTimeout,
 		DisableHTTPACValidation: disableHTTPACValidation,
 		DisableGRPCACDepsCheck:  disableGRPCACDepsCheck,
+		EnableEndpointMetrics:   enableEndpointMetrics,
 	}
 
 	err := validateConfig(&c)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ htpasswd_file: /opt/.htpasswd
 tls_cert_file: /opt/tls.cert
 tls_key_file:  /opt/tls.key
 disable_http_ac_validation: true
+enable_endpoint_metrics: true
 `
 
 	config, err := newFromYaml([]byte(yaml))
@@ -35,6 +36,7 @@ disable_http_ac_validation: true
 		TLSCertFile:             "/opt/tls.cert",
 		TLSKeyFile:              "/opt/tls.key",
 		DisableHTTPACValidation: true,
+		EnableEndpointMetrics:   true,
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {


### PR DESCRIPTION
The default histogram buckets in prometheus is from 0 to 10 seconds, so anything that takes >10 secs cannot be tracked. This commit uses duration buckets to include bigger values.