### PR TITLE
Consistent handling of empty files in CAS

### DIFF
--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -157,7 +157,7 @@ func TestEverything(t *testing.T) {
 	var found bool
 	var size int64
 
-	found, size = diskCache.Contains(cache.AC, hash)
+	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)))
 	if !found {
 		t.Fatalf("Expected to find AC item %s", hash)
 	}
@@ -166,7 +166,7 @@ func TestEverything(t *testing.T) {
 			len(acData), size)
 	}
 
-	found, size = diskCache.Contains(cache.CAS, hash)
+	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)))
 	if !found {
 		t.Fatalf("Expected to find CAS item %s", hash)
 	}
@@ -180,7 +180,7 @@ func TestEverything(t *testing.T) {
 	var data []byte
 	var rc io.ReadCloser
 
-	rc, size, err = diskCache.Get(cache.AC, hash)
+	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)))
 	if err != nil {
 		t.Error(err)
 	}
@@ -200,7 +200,7 @@ func TestEverything(t *testing.T) {
 	}
 	rc.Close()
 
-	rc, size, err = diskCache.Get(cache.CAS, hash)
+	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)))
 	if err != nil {
 		t.Error(err)
 	}
@@ -235,7 +235,7 @@ func TestEverything(t *testing.T) {
 
 	// Confirm that we can HEAD both values successfully.
 
-	found, size = diskCache.Contains(cache.AC, hash)
+	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)))
 	if !found {
 		t.Fatalf("Expected to find AC item %s", hash)
 	}
@@ -244,7 +244,7 @@ func TestEverything(t *testing.T) {
 			len(acData), size)
 	}
 
-	found, size = diskCache.Contains(cache.CAS, hash)
+	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)))
 	if !found {
 		t.Fatalf("Expected to find CAS item %s", hash)
 	}
@@ -255,7 +255,7 @@ func TestEverything(t *testing.T) {
 
 	// Confirm that we can GET both values successfully.
 
-	rc, size, err = diskCache.Get(cache.AC, hash)
+	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)))
 	if err != nil {
 		t.Error(err)
 	}
@@ -275,7 +275,7 @@ func TestEverything(t *testing.T) {
 	}
 	rc.Close()
 
-	rc, size, err = diskCache.Get(cache.CAS, hash)
+	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)))
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -64,14 +64,14 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 
 			sha256Str = hex.EncodeToString(decoded)
 
-			found, size := s.cache.Contains(cache.CAS, sha256Str)
+			found, size := s.cache.Contains(cache.CAS, sha256Str, -1)
 			if !found {
 				continue
 			}
 
 			if size < 0 {
 				// We don't know the size yet (bad http backend?).
-				r, size, err := s.cache.Get(cache.CAS, sha256Str)
+				r, size, err := s.cache.Get(cache.CAS, sha256Str, -1)
 				if r != nil {
 					defer r.Close()
 				}

--- a/server/grpc_cas.go
+++ b/server/grpc_cas.go
@@ -37,13 +37,7 @@ func (s *grpcServer) FindMissingBlobs(ctx context.Context,
 			return nil, err
 		}
 
-		if digest.SizeBytes == 0 {
-			// The hash was validated, so we know it's OK.
-			s.accessLogger.Printf("GRPC CAS HEAD %s OK", hash)
-			continue
-		}
-
-		found, _ := s.cache.Contains(cache.CAS, hash)
+		found, _ := s.cache.Contains(cache.CAS, hash, digest.GetSizeBytes())
 		if !found {
 			s.accessLogger.Printf("GRPC CAS HEAD %s NOT FOUND", hash)
 			resp.MissingBlobDigests = append(resp.MissingBlobDigests, digest)
@@ -106,7 +100,7 @@ func (s *grpcServer) getBlobData(hash string, size int64) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	rdr, sizeBytes, err := s.cache.Get(cache.CAS, hash)
+	rdr, sizeBytes, err := s.cache.Get(cache.CAS, hash, size)
 	if err != nil {
 		rdr.Close()
 		return []byte{}, err

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -573,7 +573,7 @@ func TestGrpcByteStreamDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, sz, err := diskCache.Get(cache.CAS, testBlobHash)
+	_, sz, err := diskCache.Get(cache.CAS, testBlobHash, testBlobSize)
 	if err != nil {
 		t.Fatalf("get error: %v\n", err)
 	}


### PR DESCRIPTION
Hi,

There were special handling of empty files in server/grpc_cas.go and
server/http.go. It assumed that empty files are not stored in CAS.
The reason was to handle clients (like bazel?) which in some cases
don't upload the empty blob, but do reference it. It is kind of OK
not to upload the empty blob, since it can be recongnised by hash
and trivally regenerated.

**Problem was** that server/grpc_bytestream.go,
GetValidatedActionResult in disk.go and perhaps more places, still
expected the empty blobs to be available on disk.

**This commit moves the logic into the disk.go to assure the same
logic is used consistenly everywhere.**

Would you accept this pull request, if I add and update unit tests?

BR
Ulrik Falklöf