### PR TITLE
Read After Write Guarantee

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	IdleTimeout             time.Duration             `yaml:"idle_timeout"`
 	DisableHTTPACValidation bool                      `yaml:"disable_http_ac_validation"`
 	DisableGRPCACDepsCheck  bool                      `yaml:"disable_grpc_ac_deps_check"`
+        ReadAfterWriteGuarantee bool                      `yaml:"read_after_write_guarantee"`
+        OverwriteCommited       bool                      `yaml:"overwrite_commited"`
 }
 
 // New returns a validated Config with the specified values, and an error
@@ -78,6 +80,8 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 		IdleTimeout:             idleTimeout,
 		DisableHTTPACValidation: disableHTTPACValidation,
 		DisableGRPCACDepsCheck:  disableGRPCACDepsCheck,
+                ReadAfterWriteGuarantee: false,
+                OverwriteCommited:       true,
 	}
 
 	err := validateConfig(&c)

--- a/main.go
+++ b/main.go
@@ -281,7 +281,8 @@ func main() {
 			proxyCache = s3proxy.New(c.S3CloudStorage, accessLogger, errorLogger)
 		}
 
-		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache)
+		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache,
+                                      c.ReadAfterWriteGuarantee, c.OverwriteCommited)
 
 		mux := http.NewServeMux()
 		httpServer := &http.Server{


### PR DESCRIPTION
Four related issues/scenarios addressed with this commit:

1. Client A uploads file to CAS. It becomes commited in disk storage. Later client B uploads same file with same hash overwriting the one from client A. **During second upload the disk storage changes the entry into uncommited, resulting in that file that was previously available can not be retrieved** for a while. This behviour is problematic for Bazel Remote Execution and the bazel feature builds-without-the-bytes, which expect read after write guarantee.
2. If the same file is uploaded concurrently (either by the same client or different clients) the **second one is silently discarded and the upload is acknowledge even before the upload has been completed** by the first client. This behviour is problematic for Bazel Remote Execution and the bazel feature builds-without-the bytes, which expect read after write guarantee.
3. A deferred os.Remove(tmpFilePath) after an upload, could get delayed and interfer with another upload of the same key.
4. After Put adds an uncommited entry, but before it creates a temporary file, it can become evicted by another concurrent add. Then the download would continue and could result in a file stored in CAS without entry in LRU, and it could also interfer with following concurrent uploads of the same key.

All these issues are addressed by this commit, without introducing risk for a fast uploading clients having to wait for a slower uploadling clients that are concurrently uploading the same file. Instead it adds support for concurrent uploads of the same key.