### PR TITLE
skip a few more empty CAS blob lookups

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -657,7 +657,7 @@ func (c *Cache) GetValidatedActionResult(hash string) (*pb.ActionResult, []byte,
 		}
 
 		for _, f := range tree.Root.GetFiles() {
-			if f.Digest == nil {
+			if f.Digest == nil || f.Digest.SizeBytes == 0 {
 				continue
 			}
 			found, _ := c.Contains(cache.CAS, f.Digest.Hash)
@@ -668,7 +668,7 @@ func (c *Cache) GetValidatedActionResult(hash string) (*pb.ActionResult, []byte,
 
 		for _, child := range tree.GetChildren() {
 			for _, f := range child.GetFiles() {
-				if f.Digest == nil {
+				if f.Digest == nil || f.Digest.SizeBytes == 0 {
 					continue
 				}
 				found, _ := c.Contains(cache.CAS, f.Digest.Hash)

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -261,7 +261,7 @@ func TestGrpcAc(t *testing.T) {
 	}
 }
 
-func TestGrpcAcEmptySha256(t *testing.T) {
+func TestGrpcCasEmptySha256(t *testing.T) {
 
 	// Check that we can "download" an empty blob, even if it hasn't
 	// been uploaded.


### PR DESCRIPTION
Thanks to Ulrik Falklöf <ulrik.falklof@ericsson.com> for catching these.

Background + discussion of followup work:
https://github.com/buchgr/bazel-remote/pull/266