### PR TITLE
doc: remove implicit help "command" from the help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,10 @@ NAME:
    bazel-remote - A remote build cache for Bazel
 
 USAGE:
-   bazel-remote [global options] command [command options] [arguments...]
+   bazel-remote [global options] [arguments...]
 
 DESCRIPTION:
    A remote build cache for Bazel.
-
-COMMANDS:
-   help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --config_file value              Path to a YAML configuration file. If this flag is specified then all other flags are ignored. [$BAZEL_REMOTE_CONFIG_FILE]

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	app.Description = "A remote build cache for Bazel."
 	app.Usage = "A remote build cache for Bazel"
 	app.HideVersion = true
+	app.HideHelpCommand = true
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{


### PR DESCRIPTION
bazel-remote doesn't have any "commands" in its command line args, let's hide the implicit help command.