### PR TITLE
allow concurrent Puts and proxied Gets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Returns the cache status/info.
 $ curl http://localhost:8080/status
 {
  "CurrSize": 414081715503,
+ "ReservedSize": 876400,
  "MaxSize": 8589934592000,
  "NumFiles": 621413,
  "ServerTime": 1588329927,

--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",
+        "//utils/tempfile:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@com_github_djherbis_atime//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -37,15 +37,8 @@ func checkItems(cache *Cache, expSize int64, expNum int) error {
 	if cache.lru.Len() != expNum {
 		return fmt.Errorf("expected %d files in the cache, found %d", expNum, cache.lru.Len())
 	}
-	if cache.lru.CurrentSize() != expSize {
-		return fmt.Errorf("expected %d bytes in the cache, found %d", expSize, cache.lru.CurrentSize())
-	}
-
-	// Dig into the internals of the cache to make sure that all items are committed.
-	for _, it := range cache.lru.(*sizedLRU).cache {
-		if it.Value.(*entry).value.(*lruItem).committed != true {
-			return fmt.Errorf("expected committed = true")
-		}
+	if cache.lru.TotalSize() != expSize {
+		return fmt.Errorf("expected %d bytes in the cache, found %d", expSize, cache.lru.TotalSize())
 	}
 
 	numFiles := 0
@@ -482,7 +475,7 @@ func TestMigrateFromOldDirectoryStructure(t *testing.T) {
 		t.Fatal(err)
 	}
 	testCache := New(cacheDir, 2560, nil)
-	_, numItems := testCache.Stats()
+	_, _, numItems := testCache.Stats()
 	if numItems != 3 {
 		t.Fatalf("Expected test cache size 3 but was %d", numItems)
 	}
@@ -526,7 +519,7 @@ func TestLoadExistingEntries(t *testing.T) {
 	}
 
 	testCache := New(cacheDir, blobSize*numBlobs, nil)
-	_, numItems := testCache.Stats()
+	_, _, numItems := testCache.Stats()
 	if int64(numItems) != numBlobs {
 		t.Fatalf("Expected test cache size %d but was %d",
 			numBlobs, numItems)
@@ -582,7 +575,7 @@ func TestDistinctKeyspaces(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, numItems := testCache.Stats()
+	_, _, numItems := testCache.Stats()
 	if numItems != 3 {
 		t.Fatalf("Expected test cache size 3 but was %d",
 			numItems)

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -228,7 +228,7 @@ func TestEverything(t *testing.T) {
 
 	diskCache = disk.New(cacheDir2, diskCacheSize, proxyCache)
 
-	_, numItems := diskCache.Stats()
+	_, _, numItems := diskCache.Stats()
 	if numItems != 0 {
 		t.Fatalf("Expected an empty disk cache, found %d items", numItems)
 	}

--- a/server/http.go
+++ b/server/http.go
@@ -37,11 +37,12 @@ type httpCache struct {
 }
 
 type statusPageData struct {
-	CurrSize   int64
-	MaxSize    int64
-	NumFiles   int
-	ServerTime int64
-	GitCommit  string
+	CurrSize     int64
+	ReservedSize int64
+	MaxSize      int64
+	NumFiles     int
+	ServerTime   int64
+	GitCommit    string
 }
 
 // NewHTTPCache returns a new instance of the cache.
@@ -50,7 +51,7 @@ type statusPageData struct {
 // be reported.
 func NewHTTPCache(cache *disk.Cache, accessLogger cache.Logger, errorLogger cache.Logger, validateAC bool, commit string) HTTPCache {
 
-	_, numItems := cache.Stats()
+	_, _, numItems := cache.Stats()
 
 	errorLogger.Printf("Loaded %d existing disk cache items.", numItems)
 
@@ -348,17 +349,18 @@ func addWorkerMetadataHTTP(addr string, ct string, orig []byte) (data []byte, co
 func (h *httpCache) StatusPageHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
-	currentSize, numItems := h.cache.Stats()
+	totalSize, reservedSize, numItems := h.cache.Stats()
 
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", " ")
 	enc.Encode(statusPageData{
-		MaxSize:    h.cache.MaxSize(),
-		CurrSize:   currentSize,
-		NumFiles:   numItems,
-		ServerTime: time.Now().Unix(),
-		GitCommit:  h.gitCommit,
+		MaxSize:      h.cache.MaxSize(),
+		CurrSize:     totalSize,
+		ReservedSize: reservedSize,
+		NumFiles:     numItems,
+		ServerTime:   time.Now().Unix(),
+		GitCommit:    h.gitCommit,
 	})
 }
 

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -154,13 +154,15 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 
 	data, hash := testutils.RandomDataAndHash(1024)
 
-	c := disk.New(cacheDir, 1024, nil)
+	numWorkers := 100
+
+	c := disk.New(cacheDir, int64(len(data)*numWorkers), nil)
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
 		go func() {
 			defer wg.Done()
 

--- a/utils/tempfile/BUILD.bazel
+++ b/utils/tempfile/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tempfile.go"],
+    importpath = "github.com/buchgr/bazel-remote/utils/tempfile",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
At the moment, bazel-remote only allows a single concurrent Put for a given blob. If another Put starts, while one is ongoing, we discard the second copy and return quickly, but the blob is not yet available. This can cause trouble for the second client, which assumes that the blob is available as soon as its Put finishes. The same problem also exists for Get calls when using a proxy backend.

I guess this was not a problem when bazel-remote was first written and only supported the http cache protocol, because bazel serializes those requests more than it does with the newer gRPC protocol. With gRPC, a single bazel client is able to hit this problem.

This change refactors `disk.Cache` to allow concurrent Puts and proxied Gets, by reserving space in the LRU index and using pseudo-random tempfiles, While I was at it I extracted some common code into a couple of functions and reuse them in both Put and Get.

Hopefully this fixes #267 and #318.