### PR TITLE
cache.Proxy.Put should take an io.ReadCloser instead of io.Reader

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -52,7 +52,7 @@ func (e *Error) Error() string {
 type Proxy interface {
 	// Put should make a reasonable effort to proxy this data to the backend.
 	// This is allowed to fail silently (eg when under heavy load).
-	Put(kind EntryKind, hash string, size int64, rdr io.Reader)
+	Put(kind EntryKind, hash string, size int64, rdr io.ReadCloser)
 
 	// Get should return the cache item identified by `hash`, or an error
 	// if something went wrong. If the item was not found, the io.ReadCloser

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -94,7 +94,8 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Add an item
-	err = testCache.Put(cache.CAS, contentsHash, int64(len(contents)), strings.NewReader(contents))
+	err = testCache.Put(cache.CAS, contentsHash, int64(len(contents)),
+		ioutil.NopCloser(strings.NewReader(contents)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +148,8 @@ func TestCacheEviction(t *testing.T) {
 				sha256.Size*2, len(key), key)
 		}
 
-		err := testCache.Put(cache.AC, key, int64(i), strReader)
+		err := testCache.Put(cache.AC, key, int64(i),
+			ioutil.NopCloser(strReader))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +263,7 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 // digest {contentsHash, contentsLength}.
 type proxyStub struct{}
 
-func (d proxyStub) Put(kind cache.EntryKind, hash string, size int64, rdr io.Reader) {}
+func (d proxyStub) Put(kind cache.EntryKind, hash string, size int64, rc io.ReadCloser) {}
 
 func (d proxyStub) Get(kind cache.EntryKind, hash string) (io.ReadCloser, int64, error) {
 	if hash != contentsHash {


### PR DESCRIPTION
We pass an *io.File to the cache.Proxy.Put, which should be closed.