### PR TITLE
Add k8s deployment name note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ If you want the docker container to run in the background pass the `-d` flag rig
 You can adjust the maximum cache size by appending `--max_size=N`, where N is
 the maximum size in Gibibytes.
 
+### Kubernetes note 
+
+Don't name your deployment `bazel-remote`!
+Kubernetes sets some env vars based on this name and they are overwritting env vars that `bazel-remote` is using.
+See [#257](https://github.com/buchgr/bazel-remote/issues/257) for details.
+
 ### Build your own
 
 The command below will build a docker image from source and install it into your local docker registry.

--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ the maximum size in Gibibytes.
 ### Kubernetes note 
 
 Don't name your deployment `bazel-remote`!
-Kubernetes sets some env vars based on this name and they are overwritting env vars that `bazel-remote` is using.
-See [#257](https://github.com/buchgr/bazel-remote/issues/257) for details.
+
+Kubernetes sets some environment variables based on this name,
+which conflict with the `BAZEL_REMOTE_*` environment variables that bazel-remote tries to parse.
 
 ### Build your own
 


### PR DESCRIPTION
I spent hours on it, I think it's worth capturing somewhere close to the prebuilt docker image, since this is what people are going to use on k8s mostly.