### PR TITLE
Unify entry path creation directory structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ commodity hardware and AWS servers. Outgoing bandwidth can exceed 15 Gbit/s on t
 ## HTTP/1.1 REST API
 
 Cache entries are set and retrieved by key, and there are two types of keys that can be used:
+
 1. Content addressed storage (CAS), where the key is the lowercase SHA256 hash of the stored value.
    The REST API for these entries is: `/cas/<key>` or with an optional but ignored cache pool name: `/<pool>/cas/<key>`.
 2. Action cache, where the key is an arbitrary 64 character lowercase hexadecimal string.
@@ -34,6 +35,7 @@ for GET requests and `Content-type: application/json` for PUT requests.
 **/status**
 
 Returns the cache status/info.
+
 ```
 $ curl http://localhost:8080/status
 {
@@ -49,6 +51,7 @@ $ curl http://localhost:8080/status
 
 The empty CAS blob is always available, even if the cache is empty. This can be used to test that
 a bazel-remote instance is running and accepting requests.
+
 ```
 $ curl --head --fail http://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 HTTP/1.1 200 OK
@@ -124,7 +127,7 @@ GLOBAL OPTIONS:
    --s3.disable_ssl                 Whether to disable TLS/SSL when using the S3 cache backend. (default: false, ie enable TLS/SSL) [$BAZEL_REMOTE_S3_DISABLE_SSL]
    --s3.iam_role_endpoint value     Endpoint for using IAM security credentials. By default it will look for credentials in the standard locations for the AWS platform. [$BAZEL_REMOTE_S3_IAM_ROLE_ENDPOINT]
    --s3.region value                The AWS region. Required when not specifying S3/minio access keys. [$BAZEL_REMOTE_S3_REGION]
-   --s3.new_key_format              Whether to enable the nested key format to enable higher s3 throughput. (default: false, ie use the legacy flat key format) [$BAZEL_NEW_KEY_FORMAT]
+   --s3.new_key_format              Whether to enable the nested key format to enable higher s3 throughput. (default: false, ie use the legacy flat key format) [$BAZEL_REMOTE_S3_NEW_KEY_FORMAT]
    --disable_http_ac_validation     Whether to disable ActionResult validation for HTTP requests. (default: false, ie enable validation) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
    --disable_grpc_ac_deps_check     Whether to disable ActionResult dependency checks for gRPC GetActionResult requests. (default: false, ie enable ActionCache dependency checks) [$BAZEL_REMOTE_DISABLE_GRPS_AC_DEPS_CHECK]
    --enable_endpoint_metrics        Whether to enable metrics for each HTTP/gRPC endpoint. (default: false, ie disable metrics) [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]
@@ -192,6 +195,7 @@ host: localhost
 #  access_key_id: EXAMPLE_ACCESS_KEY
 #  secret_access_key: EXAMPLE_SECRET_KEY
 #  disable_ssl: true
+#  new_key_format: false
 #
 # Provide either access_key_id/secret_access_key, or iam_role_endpoint/region.
 # iam_role_endpoint can also be left empty, and figured out automatically.
@@ -233,7 +237,7 @@ If you want the docker container to run in the background pass the `-d` flag rig
 You can adjust the maximum cache size by appending `--max_size=N`, where N is
 the maximum size in Gibibytes.
 
-### Kubernetes note 
+### Kubernetes note
 
 Don't name your deployment `bazel-remote`!
 
@@ -310,3 +314,7 @@ To avoid leaking your password in log files, you can place this flag in a
 For more details, see Bazel's [remote
 caching](https://docs.bazel.build/versions/master/remote-caching.html#run-bazel-using-the-remote-cache)
 documentation.
+
+## AWS S3 Notes
+
+If you are experiencing rate limiting issues using S3 as your artifact storage, you may want to enable the new key format using the `s3.new_key_format` flag, which enables additional prefix paths on object keys allowing additional throughput. You can read more about s3 rate limiting [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/optimizing-performance.html).

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ GLOBAL OPTIONS:
    --s3.disable_ssl                 Whether to disable TLS/SSL when using the S3 cache backend. (default: false, ie enable TLS/SSL) [$BAZEL_REMOTE_S3_DISABLE_SSL]
    --s3.iam_role_endpoint value     Endpoint for using IAM security credentials. By default it will look for credentials in the standard locations for the AWS platform. [$BAZEL_REMOTE_S3_IAM_ROLE_ENDPOINT]
    --s3.region value                The AWS region. Required when not specifying S3/minio access keys. [$BAZEL_REMOTE_S3_REGION]
+   --s3.new_key_format              Whether to enable the nested key format to enable higher s3 throughput. (default: false, ie use the legacy flat key format) [$BAZEL_NEW_KEY_FORMAT]
    --disable_http_ac_validation     Whether to disable ActionResult validation for HTTP requests. (default: false, ie enable validation) [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
    --disable_grpc_ac_deps_check     Whether to disable ActionResult dependency checks for gRPC GetActionResult requests. (default: false, ie enable ActionCache dependency checks) [$BAZEL_REMOTE_DISABLE_GRPS_AC_DEPS_CHECK]
    --enable_endpoint_metrics        Whether to enable metrics for each HTTP/gRPC endpoint. (default: false, ie disable metrics) [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -66,7 +66,7 @@ type Proxy interface {
 	Contains(kind EntryKind, hash string) (bool, int64)
 }
 
-// Key returns the proper cache key for an entry kind and hash
+// Key returns the proper cache key for an entry kind and hash.
 func Key(kind EntryKind, hash string) string {
 	return filepath.Join(kind.String(), hash[:2], hash)
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"io"
+	"path/filepath"
 )
 
 // EntryKind describes the kind of cache entry
@@ -63,4 +64,9 @@ type Proxy interface {
 	// remote end, and the size if it exists (and -1 if the size is
 	// unknown).
 	Contains(kind EntryKind, hash string) (bool, int64)
+}
+
+// Key returns the proper cache key for an entry kind and hash
+func Key(kind EntryKind, hash string) string {
+	return filepath.Join(kind.String(), hash[:2], hash)
 }

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -292,7 +292,7 @@ func (c *Cache) Put(kind cache.EntryKind, hash string, expectedSize int64, r io.
 		return nil
 	}
 
-	key := cacheKey(kind, hash)
+	key := cache.Key(kind, hash)
 
 	c.mu.Lock()
 
@@ -456,7 +456,7 @@ func (c *Cache) Get(kind cache.EntryKind, hash string, size int64) (io.ReadClose
 	}
 
 	var err error
-	key := cacheKey(kind, hash)
+	key := cache.Key(kind, hash)
 
 	available, tryProxy := c.availableOrTryProxy(key)
 
@@ -595,7 +595,7 @@ func (c *Cache) Contains(kind cache.EntryKind, hash string, size int64) (bool, i
 
 	var found bool
 	foundSize := int64(-1)
-	key := cacheKey(kind, hash)
+	key := cache.Key(kind, hash)
 
 	c.mu.Lock()
 	val, isInLru := c.lru.Get(key)
@@ -653,12 +653,8 @@ func ensureDirExists(path string) {
 	}
 }
 
-func cacheKey(kind cache.EntryKind, hash string) string {
-	return filepath.Join(kind.String(), hash[:2], hash)
-}
-
 func cacheFilePath(kind cache.EntryKind, cacheDir string, hash string) string {
-	return filepath.Join(cacheDir, cacheKey(kind, hash))
+	return filepath.Join(cacheDir, cache.Key(kind, hash))
 }
 
 // GetValidatedActionResult returns a valid ActionResult and its serialized

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -114,9 +114,10 @@ func New(s3Config *config.S3CloudStorageConfig, accessLogger cache.Logger,
 
 func (c *s3Cache) objectKey(hash string, kind cache.EntryKind) string {
 	if c.prefix == "" {
-		return fmt.Sprintf("%s/%s", kind, hash)
+		return cache.Key(kind, hash)
 	}
-	return fmt.Sprintf("%s/%s/%s", c.prefix, kind, hash)
+
+	return fmt.Sprintf("%s/%s", c.prefix, cache.Key(kind, hash))
 }
 
 // Helper function for logging responses

--- a/cache/s3proxy/s3proxy_test.go
+++ b/cache/s3proxy/s3proxy_test.go
@@ -1,0 +1,48 @@
+package s3proxy
+
+import (
+	"log"
+	"testing"
+
+	"github.com/buchgr/bazel-remote/cache"
+)
+
+func TestObjectKey(t *testing.T) {
+	result, expected := "", ""
+	logger := &log.Logger{}
+	tc := &s3Cache{
+		mcore:        nil,
+		bucket:       "test",
+		newKeyFormat: false,
+		uploadQueue:  make(chan uploadReq, 1),
+		accessLogger: logger,
+		errorLogger:  logger,
+	}
+
+	// Legacy key format tests
+	tc.newKeyFormat = false
+	tc.prefix = ""
+	result, expected = tc.objectKey("1234", cache.CAS), "cas/1234"
+	checkTestCase(t, result, expected, "legacy format without prefix")
+
+	tc.prefix = "test"
+	result, expected = tc.objectKey("1234", cache.CAS), "test/cas/1234"
+	checkTestCase(t, result, expected, "legacy format with prefix")
+
+	// New key format tests
+	tc.newKeyFormat = true
+
+	tc.prefix = ""
+	result, expected = tc.objectKey("1234", cache.CAS), "cas/12/1234"
+	checkTestCase(t, result, expected, "new format with prefix")
+
+	tc.prefix = "test"
+	result, expected = tc.objectKey("1234", cache.CAS), "test/cas/12/1234"
+	checkTestCase(t, result, expected, "new format with prefix")
+}
+
+func checkTestCase(t *testing.T, result string, expected string, testCase string) {
+	if result != expected {
+		t.Errorf("%s objectKey did not match. (result: '%s' expected: '%s'", testCase, result, expected)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type S3CloudStorageConfig struct {
 	DisableSSL      bool   `yaml:"disable_ssl"`
 	IAMRoleEndpoint string `yaml:"iam_role_endpoint"`
 	Region          string `yaml:"region"`
+	NewKeyFormat    bool   `yaml:"new_key_format"`
 }
 
 // GoogleCloudStorageConfig stores the configuration of a GCS proxy backend.

--- a/main.go
+++ b/main.go
@@ -207,6 +207,12 @@ func main() {
 			EnvVars: []string{"BAZEL_REMOTE_S3_REGION"},
 		},
 		&cli.BoolFlag{
+			Name:        "s3.new_key_format",
+			Usage:       "Whether to enable the nested key format to enable higher s3 throughput.",
+			DefaultText: "false, ie use the legacy flat key format",
+			EnvVars:     []string{"BAZEL_REMOTE_S3_NEW_KEY_FORMAT"},
+		},
+		&cli.BoolFlag{
 			Name:        "disable_http_ac_validation",
 			Usage:       "Whether to disable ActionResult validation for HTTP requests.",
 			DefaultText: "false, ie enable validation",
@@ -250,6 +256,7 @@ func main() {
 					DisableSSL:      ctx.Bool("s3.disable_ssl"),
 					IAMRoleEndpoint: ctx.String("s3.iam_role_endpoint"),
 					Region:          ctx.String("s3.region"),
+					NewKeyFormat:    ctx.Bool("s3.new_key_format"),
 				}
 			}
 			c, err = config.New(


### PR DESCRIPTION
The intent of this change is to expand the rate capacity of the s3 proxy, while at the same time unifying the path creation for the different caches.  S3 rate limiting is done by prefix (roughly translated to directory) at 3500/5500 qps.  Adding the additional depth allows for a large increase in throughput before hitting rate limits.

* Add cache.Key for common usage
* Refactor disk cache to utilize cache.Key
* Refactor s3proxy to utilize cache.Key

**DISCLAIMER**
This invalidates all existing S3 caches, if thats untenable, I'm happy to put in a flag that toggles this feature on/off for s3.  I don't want to pollute the flag space unless it's desired.