### PR TITLE
explicitly close fds

### DIFF
--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -61,6 +61,7 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 			return nil, status.Error(codes.NotFound,
 				fmt.Sprintf("%s not found in AC", req.ActionDigest.Hash))
 		}
+		defer rdr.Close()
 
 		acdata, err := ioutil.ReadAll(rdr)
 		if err != nil {

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -105,6 +105,7 @@ func (s *grpcServer) Read(req *bytestream.ReadRequest,
 		s.accessLogger.Printf(msg)
 		return status.Error(codes.NotFound, msg)
 	}
+	defer rdr.Close()
 
 	if sizeBytes != size {
 		msg := fmt.Sprintf("Retrieved item had size %d expected %d",


### PR DESCRIPTION
The ReadCloser returned by disk.Cache.Get should be closed.

I had issues with exceeding max open file descriptors,
despite hard limit set to 100 000. Commit fe90bd1,
together with this one, resolved those issues.