### PR TITLE
add option to mangle AC keys with (non-empty) instance names

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 )
 
@@ -63,4 +65,23 @@ type Proxy interface {
 	// remote end, and the size if it exists (and -1 if the size is
 	// unknown).
 	Contains(kind EntryKind, hash string) (bool, int64)
+}
+
+// TransformActionCacheKey takes an ActionCache key and an instance name
+// and returns a new ActionCache key to use instead. If the instance name
+// is empty, then the original key is returned unchanged.
+func TransformActionCacheKey(key, instance string, logger Logger) string {
+	if instance == "" {
+		return key
+	}
+
+	h := sha256.New()
+	h.Write([]byte(key))
+	h.Write([]byte(instance))
+	b := h.Sum(nil)
+	newKey := hex.EncodeToString(b[:])
+
+	logger.Printf("REMAP AC HASH %s : %s => %s", key, instance, newKey)
+
+	return newKey
 }

--- a/config/config.go
+++ b/config/config.go
@@ -36,58 +36,67 @@ type HTTPBackendConfig struct {
 
 // Config holds the top-level configuration for bazel-remote.
 type Config struct {
-	Host                       string                    `yaml:"host"`
-	Port                       int                       `yaml:"port"`
-	GRPCPort                   int                       `yaml:"grpc_port"`
-	ProfileHost                string                    `yaml:"profile_host"`
-	ProfilePort                int                       `yaml:"profile_port"`
-	Dir                        string                    `yaml:"dir"`
-	MaxSize                    int                       `yaml:"max_size"`
-	HtpasswdFile               string                    `yaml:"htpasswd_file"`
-	TLSCertFile                string                    `yaml:"tls_cert_file"`
-	TLSKeyFile                 string                    `yaml:"tls_key_file"`
-	S3CloudStorage             *S3CloudStorageConfig     `yaml:"s3_proxy"`
-	GoogleCloudStorage         *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
-	HTTPBackend                *HTTPBackendConfig        `yaml:"http_proxy"`
-	IdleTimeout                time.Duration             `yaml:"idle_timeout"`
-	DisableHTTPACValidation    bool                      `yaml:"disable_http_ac_validation"`
-	DisableGRPCACDepsCheck     bool                      `yaml:"disable_grpc_ac_deps_check"`
-	EnableEndpointMetrics      bool                      `yaml:"enable_endpoint_metrics"`
-	ExperimentalRemoteAssetAPI bool                      `yaml:"experimental_remote_asset_api"`
-	HTTPReadTimeout            time.Duration             `yaml:"http_read_timeout"`
-	HTTPWriteTimeout           time.Duration             `yaml:"http_write_timeout"`
+	Host                        string                    `yaml:"host"`
+	Port                        int                       `yaml:"port"`
+	GRPCPort                    int                       `yaml:"grpc_port"`
+	ProfileHost                 string                    `yaml:"profile_host"`
+	ProfilePort                 int                       `yaml:"profile_port"`
+	Dir                         string                    `yaml:"dir"`
+	MaxSize                     int                       `yaml:"max_size"`
+	HtpasswdFile                string                    `yaml:"htpasswd_file"`
+	TLSCertFile                 string                    `yaml:"tls_cert_file"`
+	TLSKeyFile                  string                    `yaml:"tls_key_file"`
+	S3CloudStorage              *S3CloudStorageConfig     `yaml:"s3_proxy"`
+	GoogleCloudStorage          *GoogleCloudStorageConfig `yaml:"gcs_proxy"`
+	HTTPBackend                 *HTTPBackendConfig        `yaml:"http_proxy"`
+	IdleTimeout                 time.Duration             `yaml:"idle_timeout"`
+	DisableHTTPACValidation     bool                      `yaml:"disable_http_ac_validation"`
+	DisableGRPCACDepsCheck      bool                      `yaml:"disable_grpc_ac_deps_check"`
+	EnableACKeyInstanceMangling bool                      `yaml:"enable_ac_key_instance_mangling"`
+	EnableEndpointMetrics       bool                      `yaml:"enable_endpoint_metrics"`
+	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
+	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
+	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
 }
 
 // New returns a validated Config with the specified values, and an error
 // if there were any problems with the validation.
 func New(dir string, maxSize int, host string, port int, grpcPort int,
-	profileHost string, profilePort int, htpasswdFile string,
-	tlsCertFile string, tlsKeyFile string, idleTimeout time.Duration,
-	s3 *S3CloudStorageConfig, disableHTTPACValidation bool,
-	disableGRPCACDepsCheck bool, enableEndpointMetrics bool,
+	profileHost string, profilePort int,
+	htpasswdFile string,
+	tlsCertFile string,
+	tlsKeyFile string,
+	idleTimeout time.Duration,
+	s3 *S3CloudStorageConfig,
+	disableHTTPACValidation bool,
+	disableGRPCACDepsCheck bool,
+	enableACKeyInstanceMangling bool,
+	enableEndpointMetrics bool,
 	experimentalRemoteAssetAPI bool,
-	httpReadTimeout time.Duration, httpWriteTimeout time.Duration) (*Config, error) {
+	httpReadTimeout time.Duration,
+	httpWriteTimeout time.Duration) (*Config, error) {
 	c := Config{
-		Host:                       host,
-		Port:                       port,
-		GRPCPort:                   grpcPort,
-		ProfileHost:                profileHost,
-		ProfilePort:                profilePort,
-		Dir:                        dir,
-		MaxSize:                    maxSize,
-		HtpasswdFile:               htpasswdFile,
-		TLSCertFile:                tlsCertFile,
-		TLSKeyFile:                 tlsKeyFile,
-		S3CloudStorage:             s3,
-		GoogleCloudStorage:         nil,
-		HTTPBackend:                nil,
-		IdleTimeout:                idleTimeout,
-		DisableHTTPACValidation:    disableHTTPACValidation,
-		DisableGRPCACDepsCheck:     disableGRPCACDepsCheck,
-		EnableEndpointMetrics:      enableEndpointMetrics,
-		ExperimentalRemoteAssetAPI: experimentalRemoteAssetAPI,
-		HTTPReadTimeout:            httpReadTimeout,
-		HTTPWriteTimeout:           httpWriteTimeout,
+		Host:                        host,
+		Port:                        port,
+		GRPCPort:                    grpcPort,
+		ProfileHost:                 profileHost,
+		ProfilePort:                 profilePort,
+		Dir:                         dir,
+		MaxSize:                     maxSize,
+		HtpasswdFile:                htpasswdFile,
+		TLSCertFile:                 tlsCertFile,
+		TLSKeyFile:                  tlsKeyFile,
+		S3CloudStorage:              s3,
+		GoogleCloudStorage:          nil,
+		HTTPBackend:                 nil,
+		IdleTimeout:                 idleTimeout,
+		DisableHTTPACValidation:     disableHTTPACValidation,
+		DisableGRPCACDepsCheck:      disableGRPCACDepsCheck,
+		EnableACKeyInstanceMangling: enableACKeyInstanceMangling,
+		EnableEndpointMetrics:       enableEndpointMetrics,
+		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
+		HTTPReadTimeout:             httpReadTimeout,
+		HTTPWriteTimeout:            httpWriteTimeout,
 	}
 
 	err := validateConfig(&c)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ htpasswd_file: /opt/.htpasswd
 tls_cert_file: /opt/tls.cert
 tls_key_file:  /opt/tls.key
 disable_http_ac_validation: true
+enable_ac_key_instance_mangling: true
 enable_endpoint_metrics: true
 experimental_remote_asset_api: true
 http_read_timeout: 5s
@@ -31,19 +32,20 @@ http_write_timeout: 10s
 	}
 
 	expectedConfig := &Config{
-		Host:                       "localhost",
-		Port:                       8080,
-		GRPCPort:                   9092,
-		Dir:                        "/opt/cache-dir",
-		MaxSize:                    100,
-		HtpasswdFile:               "/opt/.htpasswd",
-		TLSCertFile:                "/opt/tls.cert",
-		TLSKeyFile:                 "/opt/tls.key",
-		DisableHTTPACValidation:    true,
-		EnableEndpointMetrics:      true,
-		ExperimentalRemoteAssetAPI: true,
-		HTTPReadTimeout:            5 * time.Second,
-		HTTPWriteTimeout:           10 * time.Second,
+		Host:                        "localhost",
+		Port:                        8080,
+		GRPCPort:                    9092,
+		Dir:                         "/opt/cache-dir",
+		MaxSize:                     100,
+		HtpasswdFile:                "/opt/.htpasswd",
+		TLSCertFile:                 "/opt/tls.cert",
+		TLSKeyFile:                  "/opt/tls.key",
+		DisableHTTPACValidation:     true,
+		EnableACKeyInstanceMangling: true,
+		EnableEndpointMetrics:       true,
+		ExperimentalRemoteAssetAPI:  true,
+		HTTPReadTimeout:             5 * time.Second,
+		HTTPWriteTimeout:            10 * time.Second,
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -38,6 +38,7 @@ type grpcServer struct {
 	accessLogger cache.Logger
 	errorLogger  cache.Logger
 	depsCheck    bool
+	mangleACKeys bool
 }
 
 // ListenAndServeGRPC creates a new gRPC server and listens on the given
@@ -45,6 +46,7 @@ type grpcServer struct {
 // blocking call to https://godoc.org/google.golang.org/grpc#Server.Serve
 func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 	validateACDeps bool,
+	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
@@ -53,18 +55,20 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 		return err
 	}
 
-	return serveGRPC(listener, opts, validateACDeps, enableRemoteAssetAPI, c, a, e)
+	return serveGRPC(listener, opts, validateACDeps, mangleACKeys, enableRemoteAssetAPI, c, a, e)
 }
 
 func serveGRPC(l net.Listener, opts []grpc.ServerOption,
 	validateACDepsCheck bool,
+	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)
 	s := &grpcServer{
 		cache: c, accessLogger: a, errorLogger: e,
-		depsCheck: validateACDepsCheck,
+		depsCheck:    validateACDepsCheck,
+		mangleACKeys: mangleACKeys,
 	}
 	pb.RegisterActionCacheServer(srv, s)
 	pb.RegisterCapabilitiesServer(srv, s)

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -39,6 +39,11 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 	req *pb.GetActionResultRequest) (*pb.ActionResult, error) {
 
 	logPrefix := "GRPC AC GET"
+
+	if s.mangleACKeys {
+		req.ActionDigest.Hash = cache.TransformActionCacheKey(req.ActionDigest.Hash, req.InstanceName, s.accessLogger)
+	}
+
 	err := s.validateHash(req.ActionDigest.Hash, req.ActionDigest.SizeBytes, logPrefix)
 	if err != nil {
 		return nil, err

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -77,6 +77,7 @@ func TestMain(m *testing.M) {
 	listener = bufconn.Listen(bufSize)
 
 	validateAC := true
+	mangleACKeys := false
 	enableRemoteAssetAPI := true
 
 	go func() {
@@ -84,6 +85,7 @@ func TestMain(m *testing.M) {
 			listener,
 			[]grpc.ServerOption{},
 			validateAC,
+			mangleACKeys,
 			enableRemoteAssetAPI,
 			diskCache, accessLogger, errorLogger)
 		if err2 != nil {


### PR DESCRIPTION
In some client setups, untracked local files can be used by an action without being included in the Action message, which causes action cache collisions: https://github.com/bazelbuild/bazel/issues/4558

Ideally this should be fixed on the client side (either in the client, or in the build configuration), but it is not always easy to do in practice.

As a workaround, this patch adds a setting to mangle ActionCache keys with the instance name provided by the client (if it is not empty), to produce a new ActionCache key. Clients are then able to specify a different instance name whenever a change is made that could affect these untracked inputs. The instance name value could be something like the hash of the compiler version. This allows multiple ActionCache items to exist in the cache, without requiring a change to the on-disk storage format.

This feature is disabled by default, since it would cause cache invalidations for existing users.

Fixes #15.