### PR TITLE
Add AC hit rate metrics with prometheus labels

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//config:go_default_library",
         "//server:go_default_library",
         "//utils/idle:go_default_library",
+        "//utils/metrics:go_default_library",
         "//utils/rlimit:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ host: localhost
 
 # If true, enable experimental remote asset API support:
 #experimental_remote_asset_api: true
+
+# Allows mapping HTTP and gRPC headers to prometheus
+# labels. Headers can be set by bazel client as:
+# --remote_header=os=ubuntu18-04. Not all counters are
+# affected.
+#metrics:
+#  categories:
+#    os:
+#      - rhel7
+#      - rhel8
+#      - ubuntu16-04
+#      - ubuntu18-04
+#    branch:
+#      - master
+#    user:
+#      - ci
+
 ```
 
 ## Docker

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -21,6 +21,8 @@ const (
 	// used for HTTP when running with the --disable_http_ac_validation
 	// commandline flag.
 	RAW
+
+	UNKNOWN
 )
 
 func (e EntryKind) String() string {
@@ -30,7 +32,10 @@ func (e EntryKind) String() string {
 	if e == CAS {
 		return "cas"
 	}
-	return "raw"
+	if e == RAW {
+		return "raw"
+	}
+	return "unknown"
 }
 
 // Logger is designed to be satisfied by log.Logger.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,11 @@ type HTTPBackendConfig struct {
 	BaseURL string `yaml:"url"`
 }
 
+// Metrics stores configuration for prometheus metrics.
+type Metrics struct {
+	Categories map[string][]string `yaml:"categories"`
+}
+
 // Config holds the top-level configuration for bazel-remote.
 type Config struct {
 	Host                        string                    `yaml:"host"`
@@ -55,6 +60,7 @@ type Config struct {
 	DisableGRPCACDepsCheck      bool                      `yaml:"disable_grpc_ac_deps_check"`
 	EnableACKeyInstanceMangling bool                      `yaml:"enable_ac_key_instance_mangling"`
 	EnableEndpointMetrics       bool                      `yaml:"enable_endpoint_metrics"`
+	Metrics                     *Metrics                  `yaml:"metrics"`
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
@@ -73,6 +79,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 	disableGRPCACDepsCheck bool,
 	enableACKeyInstanceMangling bool,
 	enableEndpointMetrics bool,
+	metrics *Metrics,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration) (*Config, error) {
@@ -95,6 +102,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 		DisableGRPCACDepsCheck:      disableGRPCACDepsCheck,
 		EnableACKeyInstanceMangling: enableACKeyInstanceMangling,
 		EnableEndpointMetrics:       enableEndpointMetrics,
+		Metrics:                     metrics,
 		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/buchgr/bazel-remote/config"
 	"github.com/buchgr/bazel-remote/server"
 	"github.com/buchgr/bazel-remote/utils/idle"
+	"github.com/buchgr/bazel-remote/utils/metrics"
 	"github.com/buchgr/bazel-remote/utils/rlimit"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -283,6 +284,7 @@ func main() {
 				ctx.Bool("disable_grpc_ac_deps_check"),
 				ctx.Bool("enable_ac_key_instance_mangling"),
 				ctx.Bool("enable_endpoint_metrics"),
+				nil,
 				ctx.Bool("experimental_remote_asset_api"),
 				ctx.Duration("http_read_timeout"),
 				ctx.Duration("http_write_timeout"),
@@ -311,6 +313,7 @@ func main() {
 
 		accessLogger := log.New(os.Stdout, "", logFlags)
 		errorLogger := log.New(os.Stderr, "", logFlags)
+		metrics := metrics.NewMetrics(c.Metrics)
 
 		var proxyCache cache.Proxy
 		if c.GoogleCloudStorage != nil {
@@ -344,8 +347,7 @@ func main() {
 		}
 
 		validateAC := !c.DisableHTTPACValidation
-		h := server.NewHTTPCache(diskCache, accessLogger, errorLogger, validateAC, c.EnableACKeyInstanceMangling, gitCommit)
-
+		h := server.NewHTTPCache(diskCache, accessLogger, errorLogger, metrics, validateAC, c.EnableACKeyInstanceMangling, gitCommit)
 		var htpasswdSecrets auth.SecretProvider
 		cacheHandler := h.CacheHandler
 		if c.HtpasswdFile != "" {
@@ -444,7 +446,7 @@ func main() {
 					validateAC,
 					c.EnableACKeyInstanceMangling,
 					enableRemoteAssetAPI,
-					diskCache, accessLogger, errorLogger)
+					diskCache, accessLogger, errorLogger, metrics)
 				if err3 != nil {
 					log.Fatal(err3)
 				}

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//cache:go_default_library",
         "//cache/disk:go_default_library",
         "//utils/idle:go_default_library",
+        "//utils/metrics:go_default_library",
         "@com_github_abbot_go_http_auth//:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/asset/v1:go_default_library",
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -73,6 +73,7 @@ func TestMain(m *testing.M) {
 
 	accessLogger := testutils.NewSilentLogger()
 	errorLogger := testutils.NewSilentLogger()
+	metrics := testutils.NewMetricsStub()
 
 	listener = bufconn.Listen(bufSize)
 
@@ -87,7 +88,7 @@ func TestMain(m *testing.M) {
 			validateAC,
 			mangleACKeys,
 			enableRemoteAssetAPI,
-			diskCache, accessLogger, errorLogger)
+			diskCache, accessLogger, errorLogger, metrics)
 		if err2 != nil {
 			fmt.Println(err2)
 			os.Exit(1)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -36,8 +36,7 @@ func TestDownloadFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, blobSize, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
-
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	req, err := http.NewRequest("GET", "/cas/"+hash, bytes.NewReader([]byte{}))
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +98,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 1000*1024, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -157,7 +156,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	numWorkers := 100
 
 	c := disk.New(cacheDir, int64(len(data)*numWorkers), nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -203,7 +202,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -245,7 +244,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	c := disk.New(cacheDir, 2048, nil)
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), validate, mangle, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -302,7 +301,7 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	c := disk.New(cacheDir, 2048, nil)
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), validate, mangle, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -325,7 +324,7 @@ func TestStatusPage(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -466,7 +465,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 	emptyCache := disk.New(cacheDir, 1024, nil)
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), testutils.NewMetricsStub(), true, false, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))

--- a/utils/BUILD.bazel
+++ b/utils/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = ["testutils.go"],
     importpath = "github.com/buchgr/bazel-remote/utils",
     visibility = ["//visibility:public"],
+    deps = [
+        "//utils/metrics:go_default_library",
+    ]
 )

--- a/utils/metrics/BUILD.bazel
+++ b/utils/metrics/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/buchgr/bazel-remote/utils/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+    ],
+)

--- a/utils/metrics/metrics.go
+++ b/utils/metrics/metrics.go
@@ -1,0 +1,187 @@
+package metrics
+
+import (
+	"github.com/buchgr/bazel-remote/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"strings"
+)
+
+// TODO Add test cases for this file
+
+type Method int
+type Status int
+type Kind int
+type Protocol int
+
+const (
+	METHOD_GET Method = iota
+	METHOD_HEAD
+	METHOD_PUT
+	METHOD_OTHER
+)
+
+const (
+	OK Status = iota
+	NOT_FOUND
+	OTHER_STATUS
+)
+
+const (
+	AC Kind = iota
+	CAS
+)
+
+const (
+	HTTP Protocol = iota
+	GRPC
+)
+
+func (e Method) String() string {
+	// Actually HTTP names, but can be conceptually mapped also to GRPC protocol.
+	if e == METHOD_GET {
+		return "GET"
+	}
+	if e == METHOD_HEAD {
+		return "HEAD"
+	}
+	if e == METHOD_PUT {
+		return "PUT"
+	}
+	return "other"
+}
+
+func (e Status) String() string {
+	// Names that works for both HTTP and GRPC, instead of HTTP or GRPC specific codes.
+	if e == OK {
+		return "OK"
+	}
+	if e == NOT_FOUND {
+		return "NotFound"
+	}
+	return "other"
+}
+
+func (e Kind) String() string {
+	if e == AC {
+		return "AC"
+	}
+	if e == CAS {
+		return "CAS"
+	}
+	return "other"
+}
+
+type Metrics interface {
+	// TODO Document interface
+	IncomingRequestCompleted(kind Kind, method Method, status Status, headers map[string][]string, protocol Protocol)
+}
+
+type metrics struct {
+	categoryValues               map[string]map[string]struct{}
+	counterIncomingCompletedReqs *prometheus.CounterVec
+}
+
+func NewMetrics(config *config.Metrics) Metrics {
+
+	labels := []string{"method", "status", "kind"}
+	categoryValues := make(map[string]map[string]struct{})
+
+	if config != nil && config.Categories != nil {
+		for categoryName, whiteListedValues := range config.Categories {
+			// Normalize to lower case since canonical for gRPC headers
+			// and convention for prometheus.
+			categoryName := strings.ToLower(categoryName)
+
+			// Store white listed category values as set for efficient access
+			whiteListedSet := make(map[string]struct{})
+			for _, categoryValue := range whiteListedValues {
+				whiteListedSet[categoryValue] = struct{}{}
+			}
+			categoryValues[categoryName] = whiteListedSet
+
+			// Construct a prometheus label for each category.
+			// Prometheus does not allow changing set of
+			// labels until next time bazel-remote is
+			// restarted.
+			labels = append(labels, categoryName)
+		}
+	}
+
+	// For now we only count AC requests, and only the most common status codes,
+	// becuse:
+	//
+	//  - No identified use case for others.
+	//  - Limit number of prometheus time series (if many configured categories).
+	//  - Reduce performance overhead of counters (if many configured categories).
+	//  - Would otherwise require injecting invocations in more places.
+	//
+	// But the naming, and the labels, of the counter, are generic to allow
+	// counting additional requests types or status codes in the future. Without
+	// having to rename the counter and get issues with non continous history of
+	// metrics.
+
+	counterIncomingCompletedReqs := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bazel_remote_incoming_requests_completed_total",
+			Help: "The number of incoming HTTP and gRPC request. Currently only AC requests",
+		},
+		labels)
+
+	m := &metrics{
+		categoryValues:               categoryValues,
+		counterIncomingCompletedReqs: counterIncomingCompletedReqs,
+	}
+	return m
+}
+
+func getLabelValueFromHeaderValues(headerValues []string, whiteListedValues map[string]struct{}) string {
+	for _, headerValue := range headerValues {
+		// Prometheus only allows one value per label.
+		// Pick the first white listed header value we find.
+		if _, ok := whiteListedValues[headerValue]; ok {
+			return headerValue
+		}
+	}
+
+	// The values found in the header has not been white listed in
+	// the configuration file. Represent them as "other".
+	//
+	// The white listening is an attempt to avoid polluting
+	// prometheus with too many different time series.
+	//
+	// https://prometheus.io/docs/practices/naming/ warns about:
+	//
+	//   "CAUTION: Remember that every unique combination of key-value
+	//   label pairs represents a new time series, which can dramatically
+	//   increase the amount of data stored. Do not use labels to store
+	//   dimensions with high cardinality (many different label values),
+	//   such as user IDs, email addresses, or other unbounded sets of
+	//   values."
+	//
+	// It would have been nice if bazel-remote could reload the set
+	// of white listed values from updated configuration file, by
+	// SIGHUP signal instead of having to restart bazel-remote.
+	return "other"
+}
+
+func (m *metrics) IncomingRequestCompleted(kind Kind, method Method, status Status, headers map[string][]string, protocol Protocol) {
+	labels := make(prometheus.Labels)
+	labels["method"] = method.String()
+	labels["status"] = status.String()
+	labels["kind"] = kind.String()
+	for labelName := range m.categoryValues {
+		// The canonical form of gRPC and HTTP/2 headers is lowercase "category"
+		headerName := labelName
+		if protocol == HTTP {
+			// but the golang http library is normalizing HTTP/1.1 headers as "Category".
+			headerName = strings.Title(headerName)
+		}
+		if headerValues, ok := headers[headerName]; ok {
+			labels[labelName] = getLabelValueFromHeaderValues(headerValues, m.categoryValues[labelName])
+		} else {
+			labels[labelName] = "" // no header for this label
+		}
+	}
+	m.counterIncomingCompletedReqs.With(labels).Inc()
+}

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/buchgr/bazel-remote/utils/metrics"
 )
 
 // TempDir creates a temporary directory and returns its name. If an error
@@ -46,4 +48,14 @@ func RandomDataAndHash(size int64) ([]byte, string) {
 // for tests.
 func NewSilentLogger() *log.Logger {
 	return log.New(ioutil.Discard, "", 0)
+}
+
+type metricsStub struct{}
+
+func NewMetricsStub() *metricsStub {
+	return new(metricsStub)
+}
+
+func (m metricsStub) IncomingRequestCompleted(kind metrics.Kind, method metrics.Method, status metrics.Status, headers map[string][]string, protocol metrics.Protocol) {
+	// Do nothing
 }


### PR DESCRIPTION
This is a draft, not ready to be merged. I wait with test cases until getting feedback about the main functionality. 

Summary of what is added by this commit:

 - Prometheus counter for cache hit ratio of only AC requests.
 - Support for prometheus labels based on custom HTTP and gRPC headers.

Cache hit ratio for CAS entries is easily misinterpreted. Example:

  A typical action cache hit often involves 3 or more HTTP requests:

    GET AC 200
    GET CAS 200 (.o file)
    GET CAS 200 (.d file)
    ...

  But a cache miss for the same action is typically a single HTTP request:

    GET AC 404

The ratio between all HTTP GET 200 vs HTTP GET 404 above does not represent
the cache hit ratio experienced by the user for actions. The ratio of only
AC requests is easier to reason about, especially when AC requests checks
existence of CAS dependencies.

The number of AC hits and misses can be directly compared against numbers
printed in the end of each build by bazel client. And against other
prometheus counters produced by remote execution systems for executed actions.

An understanding about the reason for cache misses is necessary to improve the
cache hit ratio. It could be that the system has been configured in a way
that prevent artifacts from being reused between different OS. Or that the
cache is only populated by CI jobs on master, potentially resulting in cache
misses for other users, etc. It becomes easier to notice such patterns, if
cache hit ratio could be calculated for different categories of builds.
Such categories can be set as custom headers via bazel flags
--remote_header=branch=master and applied as prometheus labels. Mapping of
headers to prometheus labels are controlled in bazel-remote's config file.

The ratio between cache uploads and cache misses is also relevant, as an
view about which categories are not uploading their result. The ratio of cache
uploads can also indicate if much is uploaded but seldom requested. E.g. does it
make sense to populate central caches from interactive builds or only from CI?

Categories and custom headers, could also be set for an overview about:
 - Bazel versions using a cache instance?
 - How much separate organizations are using a cache instance?
 - From which network traffic originates?
 - Which products are built using the cache?
 - If the traffic comes via proxy adding its own headers?
 - Distinguish dummy requests for monitoring the cache, from real requests?
 - ...