### PR TITLE
Add AC hit rate metrics with prometheus labels (alternative implementation with decorator)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//cache/gcsproxy:go_default_library",
         "//cache/httpproxy:go_default_library",
         "//cache/s3proxy:go_default_library",
+        "//cache/metricsdecorator:go_default_library",
         "//config:go_default_library",
         "//server:go_default_library",
         "//utils/idle:go_default_library",

--- a/README.md
+++ b/README.md
@@ -223,6 +223,23 @@ host: localhost
 
 # If true, enable experimental remote asset API support:
 #experimental_remote_asset_api: true
+
+# Allows mapping HTTP and gRPC headers to prometheus
+# labels. Headers can be set by bazel client as:
+# --remote_header=os=ubuntu18-04. Not all counters are
+# affected.
+#metrics:
+#  categories:
+#    os:
+#      - rhel7
+#      - rhel8
+#      - ubuntu16-04
+#      - ubuntu18-04
+#    branch:
+#      - master
+#    user:
+#      - ci
+
 ```
 
 ## Docker

--- a/cache/BUILD.bazel
+++ b/cache/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = ["cache.go"],
     importpath = "github.com/buchgr/bazel-remote/cache",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+    ],
 )

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -78,7 +78,7 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Non-existing item
-	rdr, _, err := testCache.Get(cache.CAS, contentsHash, contentsLength)
+	rdr, _, err := testCache.Get(cache.CAS, contentsHash, contentsLength, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestCacheBasics(t *testing.T) {
 
 	// Add an item
 	err = testCache.Put(cache.CAS, contentsHash, int64(len(contents)),
-		ioutil.NopCloser(strings.NewReader(contents)))
+		ioutil.NopCloser(strings.NewReader(contents)), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestCacheBasics(t *testing.T) {
 	}
 
 	// Get the item back
-	rdr, sizeBytes, err := testCache.Get(cache.CAS, contentsHash, contentsLength)
+	rdr, sizeBytes, err := testCache.Get(cache.CAS, contentsHash, contentsLength, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +142,7 @@ func TestCacheEviction(t *testing.T) {
 		}
 
 		err := testCache.Put(cache.AC, key, int64(i),
-			ioutil.NopCloser(strReader))
+			ioutil.NopCloser(strReader), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,16 +164,16 @@ func TestCachePutWrongSize(t *testing.T) {
 
 	var err error
 
-	err = testCache.Put(cache.AC, hash, int64(len(content)), strings.NewReader(content))
+	err = testCache.Put(cache.AC, hash, int64(len(content)), strings.NewReader(content), nil)
 	if err != nil {
 		t.Fatal("Expected success", err)
 	}
 
-	err = testCache.Put(cache.AC, hash, int64(len(content))+1, strings.NewReader(content))
+	err = testCache.Put(cache.AC, hash, int64(len(content))+1, strings.NewReader(content), nil)
 	if err == nil {
 		t.Error("Expected error due to size being different")
 	}
-	err = testCache.Put(cache.AC, hash, int64(len(content))-1, strings.NewReader(content))
+	err = testCache.Put(cache.AC, hash, int64(len(content))-1, strings.NewReader(content), nil)
 	if err == nil {
 		t.Error("Expected error due to size being different")
 	}
@@ -188,27 +188,27 @@ func TestCacheGetContainsWrongSize(t *testing.T) {
 	var found bool
 	var rdr io.ReadCloser
 
-	err := testCache.Put(cache.CAS, contentsHash, contentsLength, strings.NewReader(contents))
+	err := testCache.Put(cache.CAS, contentsHash, contentsLength, strings.NewReader(contents), nil)
 	if err != nil {
 		t.Fatal("Expected success", err)
 	}
 
-	found, _ = testCache.Contains(cache.CAS, contentsHash, contentsLength+1)
+	found, _ = testCache.Contains(cache.CAS, contentsHash, contentsLength+1, nil)
 	if found {
 		t.Error("Expected not found, due to size being different")
 	}
 
-	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, contentsLength+1)
+	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, contentsLength+1, nil)
 	if rdr != nil {
 		t.Error("Expected not found, due to size being different")
 	}
 
-	found, _ = testCache.Contains(cache.CAS, contentsHash, -1)
+	found, _ = testCache.Contains(cache.CAS, contentsHash, -1, nil)
 	if !found {
 		t.Error("Expected found, when unknown size")
 	}
 
-	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, -1)
+	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, -1, nil)
 	if rdr == nil {
 		t.Error("Expected found, when unknown size")
 	}
@@ -225,12 +225,12 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 
 	// The proxyStub contains the digest {contentsHash, contentsLength}.
 
-	found, _ = testCache.Contains(cache.CAS, contentsHash, contentsLength+1)
+	found, _ = testCache.Contains(cache.CAS, contentsHash, contentsLength+1, nil)
 	if found {
 		t.Error("Expected not found, due to size being different")
 	}
 
-	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, contentsLength+1)
+	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, contentsLength+1, nil)
 	if rdr != nil {
 		t.Error("Expected not found, due to size being different")
 	}
@@ -238,12 +238,12 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	found, _ = testCache.Contains(cache.CAS, contentsHash, -1)
+	found, _ = testCache.Contains(cache.CAS, contentsHash, -1, nil)
 	if !found {
 		t.Error("Expected found, when unknown size")
 	}
 
-	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, -1)
+	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, -1, nil)
 	if rdr == nil {
 		t.Error("Expected found, when unknown size")
 	}
@@ -302,12 +302,12 @@ func putGetCompareBytes(kind cache.EntryKind, hash string, data []byte, testCach
 
 	r := bytes.NewReader(data)
 
-	err := testCache.Put(kind, hash, int64(len(data)), r)
+	err := testCache.Put(kind, hash, int64(len(data)), r, nil)
 	if err != nil {
 		return err
 	}
 
-	rdr, sizeBytes, err := testCache.Get(kind, hash, int64(len(data)))
+	rdr, sizeBytes, err := testCache.Get(kind, hash, int64(len(data)), nil)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func TestCacheExistingFiles(t *testing.T) {
 	}
 
 	// Adding a new file should evict items[0] (the oldest)
-	err = testCache.Put(cache.CAS, contentsHash, int64(len(contents)), strings.NewReader(contents))
+	err = testCache.Put(cache.CAS, contentsHash, int64(len(contents)), strings.NewReader(contents), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestCacheExistingFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found, _ := testCache.Contains(cache.CAS, "f53b46209596d170f7659a414c9ff9f6b545cf77ffd6e1cbe9bcc57e1afacfbd", contentsLength)
+	found, _ := testCache.Contains(cache.CAS, "f53b46209596d170f7659a414c9ff9f6b545cf77ffd6e1cbe9bcc57e1afacfbd", contentsLength, nil)
 	if found {
 		t.Fatalf("%s should have been evicted", items[0])
 	}
@@ -413,7 +413,7 @@ func TestCacheBlobTooLarge(t *testing.T) {
 
 	for k := range []cache.EntryKind{cache.AC, cache.RAW} {
 		kind := cache.EntryKind(k)
-		err := testCache.Put(kind, hashStr("foo"), 10000, strings.NewReader(contents))
+		err := testCache.Put(kind, hashStr("foo"), 10000, strings.NewReader(contents), nil)
 		if err == nil {
 			t.Fatal("Expected an error")
 		}
@@ -435,14 +435,14 @@ func TestCacheCorruptedCASBlob(t *testing.T) {
 	testCache := New(cacheDir, 1000, nil)
 
 	err := testCache.Put(cache.CAS, hashStr("foo"), int64(len(contents)),
-		strings.NewReader(contents))
+		strings.NewReader(contents), nil)
 	if err == nil {
 		t.Fatal("expected hash mismatch error")
 	}
 
 	// We expect the upload to succeed without validation:
 	err = testCache.Put(cache.RAW, hashStr("foo"), int64(len(contents)),
-		strings.NewReader(contents))
+		strings.NewReader(contents), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,17 +481,17 @@ func TestMigrateFromOldDirectoryStructure(t *testing.T) {
 	}
 
 	var found bool
-	found, _ = testCache.Contains(cache.AC, acHash, 512)
+	found, _ = testCache.Contains(cache.AC, acHash, 512, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain AC entry '%s'", acHash)
 	}
 
-	found, _ = testCache.Contains(cache.CAS, casHash1, 1024)
+	found, _ = testCache.Contains(cache.CAS, casHash1, 1024, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain CAS entry '%s'", casHash1)
 	}
 
-	found, _ = testCache.Contains(cache.CAS, casHash2, 1024)
+	found, _ = testCache.Contains(cache.CAS, casHash2, 1024, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain CAS entry '%s'", casHash2)
 	}
@@ -527,17 +527,17 @@ func TestLoadExistingEntries(t *testing.T) {
 
 	var found bool
 
-	found, _ = testCache.Contains(cache.AC, acHash, blobSize)
+	found, _ = testCache.Contains(cache.AC, acHash, blobSize, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain AC entry '%s'", acHash)
 	}
 
-	found, _ = testCache.Contains(cache.CAS, casHash, blobSize)
+	found, _ = testCache.Contains(cache.CAS, casHash, blobSize, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain CAS entry '%s'", casHash)
 	}
 
-	found, _ = testCache.Contains(cache.RAW, rawHash, blobSize)
+	found, _ = testCache.Contains(cache.RAW, rawHash, blobSize, nil)
 	if !found {
 		t.Fatalf("Expected cache to contain RAW entry '%s'", rawHash)
 	}
@@ -671,7 +671,7 @@ func TestHttpProxyBackend(t *testing.T) {
 	blob, casHash := testutils.RandomDataAndHash(blobSize)
 
 	// Non-existing item
-	r, _, err := testCache.Get(cache.CAS, casHash, blobSize)
+	r, _, err := testCache.Get(cache.CAS, casHash, blobSize, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -684,7 +684,7 @@ func TestHttpProxyBackend(t *testing.T) {
 	}
 
 	err = testCache.Put(cache.CAS, casHash, int64(len(blob)),
-		bytes.NewReader(blob))
+		bytes.NewReader(blob), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -705,12 +705,12 @@ func TestHttpProxyBackend(t *testing.T) {
 	// Confirm that it does not contain the item we added to the
 	// first testCache and the proxy backend.
 
-	found, _ := testCache.Contains(cache.CAS, casHash, blobSize)
+	found, _ := testCache.Contains(cache.CAS, casHash, blobSize, nil)
 	if found {
 		t.Fatalf("Expected the cache not to contain %s", casHash)
 	}
 
-	r, _, err = testCache.Get(cache.CAS, casHash, blobSize)
+	r, _, err = testCache.Get(cache.CAS, casHash, blobSize, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -721,13 +721,13 @@ func TestHttpProxyBackend(t *testing.T) {
 	// Add the proxy backend and check that we can Get the item.
 	testCache.proxy = proxy
 
-	found, _ = testCache.Contains(cache.CAS, casHash, blobSize)
+	found, _ = testCache.Contains(cache.CAS, casHash, blobSize, nil)
 	if !found {
 		t.Fatalf("Expected the cache to contain %s (via the proxy)",
 			casHash)
 	}
 
-	r, fetchedSize, err := testCache.Get(cache.CAS, casHash, blobSize)
+	r, fetchedSize, err := testCache.Get(cache.CAS, casHash, blobSize, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -772,7 +772,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	grokHashStr := hex.EncodeToString(grokHash[:])
 
 	err = testCache.Put(cache.CAS, grokHashStr, int64(len(grokData)),
-		bytes.NewReader(grokData))
+		bytes.NewReader(grokData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -782,7 +782,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	fooHashStr := hex.EncodeToString(fooHash[:])
 
 	err = testCache.Put(cache.CAS, fooHashStr, int64(len(fooData)),
-		bytes.NewReader(fooData))
+		bytes.NewReader(fooData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -814,7 +814,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	barDataHashStr := hex.EncodeToString(barDataHash[:])
 
 	err = testCache.Put(cache.CAS, barDataHashStr, int64(len(barData)),
-		bytes.NewReader(barData))
+		bytes.NewReader(barData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,7 +839,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	rootDataHashStr := hex.EncodeToString(rootDataHash[:])
 
 	err = testCache.Put(cache.CAS, rootDataHashStr, int64(len(rootData)),
-		bytes.NewReader(rootData))
+		bytes.NewReader(rootData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -856,7 +856,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	treeDataHashStr := hex.EncodeToString(treeDataHash[:])
 
 	err = testCache.Put(cache.CAS, treeDataHashStr, int64(len(treeData)),
-		bytes.NewReader(treeData))
+		bytes.NewReader(treeData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -898,7 +898,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	arDataHashStr := hex.EncodeToString(arDataHash[:])
 
 	err = testCache.Put(cache.AC, arDataHashStr, int64(len(arData)),
-		bytes.NewReader(arData))
+		bytes.NewReader(arData), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +910,7 @@ func TestGetValidatedActionResult(t *testing.T) {
 	// to assume that the value should be returned unchanged by the cache
 	// layer.
 
-	rAR, rData, err := testCache.GetValidatedActionResult(arDataHashStr)
+	rAR, rData, err := testCache.GetValidatedActionResult(arDataHashStr, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -107,7 +107,7 @@ func TestEverything(t *testing.T) {
 
 	// PUT two different values with the same key in ac and cas.
 
-	err = diskCache.Put(cache.AC, hash, int64(len(acData)), bytes.NewReader(acData))
+	err = diskCache.Put(cache.AC, hash, int64(len(acData)), bytes.NewReader(acData), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +124,7 @@ func TestEverything(t *testing.T) {
 	}
 	s.mu.Unlock()
 
-	err = diskCache.Put(cache.CAS, hash, int64(len(casData)), bytes.NewReader(casData))
+	err = diskCache.Put(cache.CAS, hash, int64(len(casData)), bytes.NewReader(casData), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -157,7 +157,7 @@ func TestEverything(t *testing.T) {
 	var found bool
 	var size int64
 
-	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)))
+	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)), nil)
 	if !found {
 		t.Fatalf("Expected to find AC item %s", hash)
 	}
@@ -166,7 +166,7 @@ func TestEverything(t *testing.T) {
 			len(acData), size)
 	}
 
-	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)))
+	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)), nil)
 	if !found {
 		t.Fatalf("Expected to find CAS item %s", hash)
 	}
@@ -180,7 +180,7 @@ func TestEverything(t *testing.T) {
 	var data []byte
 	var rc io.ReadCloser
 
-	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)))
+	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -200,7 +200,7 @@ func TestEverything(t *testing.T) {
 	}
 	rc.Close()
 
-	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)))
+	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -235,7 +235,7 @@ func TestEverything(t *testing.T) {
 
 	// Confirm that we can HEAD both values successfully.
 
-	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)))
+	found, size = diskCache.Contains(cache.AC, hash, int64(len(acData)), nil)
 	if !found {
 		t.Fatalf("Expected to find AC item %s", hash)
 	}
@@ -244,7 +244,7 @@ func TestEverything(t *testing.T) {
 			len(acData), size)
 	}
 
-	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)))
+	found, size = diskCache.Contains(cache.CAS, hash, int64(len(casData)), nil)
 	if !found {
 		t.Fatalf("Expected to find CAS item %s", hash)
 	}
@@ -255,7 +255,7 @@ func TestEverything(t *testing.T) {
 
 	// Confirm that we can GET both values successfully.
 
-	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)))
+	rc, size, err = diskCache.Get(cache.AC, hash, int64(len(acData)), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -275,7 +275,7 @@ func TestEverything(t *testing.T) {
 	}
 	rc.Close()
 
-	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)))
+	rc, size, err = diskCache.Get(cache.CAS, hash, int64(len(casData)), nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cache/metricsdecorator/BUILD.bazel
+++ b/cache/metricsdecorator/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "metricsdecorator.go",
+    ],
+    importpath = "github.com/buchgr/bazel-remote/cache/metricsdecorator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config:go_default_library",
+        "//cache:go_default_library",
+        "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+    ],
+)
+

--- a/cache/metricsdecorator/metricsdecorator.go
+++ b/cache/metricsdecorator/metricsdecorator.go
@@ -1,0 +1,200 @@
+package metricsdecorator
+
+// This is a decorator for any implementation of the cache.CasAcCache interface.
+// It adds prometheus metrics for the cache requests.
+//
+// The decorator can report cache miss if AC is found but referenced CAS entries are missing.
+// That is possible since GetValidatedActionResult is part of the cache.CasAcCache
+// interface, not only the low level Get method.
+
+import (
+	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"io"
+	"strings"
+
+	pb "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+)
+
+type metrics struct {
+	categoryValues      map[string]map[string]struct{}
+	counterIncomingReqs *prometheus.CounterVec
+	parent              cache.CasAcCache
+}
+
+const statusOK = "ok"
+const statusNotFound = "notFound"
+const statusError = "error"
+
+const methodGet = "get"
+const methodPut = "put"
+const methodContains = "contains"
+
+// TODO add test cases for this file
+
+func NewMetricsDecorator(config *config.Metrics, parent cache.CasAcCache) cache.CasAcCache {
+
+	labels := []string{"method", "status", "kind"}
+	categoryValues := make(map[string]map[string]struct{})
+
+	if config != nil && config.Categories != nil {
+		for categoryName, allowedValues := range config.Categories {
+			// Normalize to lower case since canonical for gRPC headers
+			// and convention for prometheus.
+			categoryName := strings.ToLower(categoryName)
+
+			// Store allowed category values as set for efficient access
+			allowedValuesSet := make(map[string]struct{})
+			for _, categoryValue := range allowedValues {
+				allowedValuesSet[categoryValue] = struct{}{}
+			}
+			categoryValues[categoryName] = allowedValuesSet
+
+			// Construct a prometheus label for each category.
+			// Prometheus does not allow changing set of
+			// labels until next time bazel-remote is
+			// restarted.
+			labels = append(labels, categoryName)
+		}
+	}
+
+	// For now we only count AC requests, and only the most common status codes,
+	// becuse:
+	//
+	//  - No identified use case for others.
+	//  - Limit number of prometheus time series (if many configured categories).
+	//  - Reduce performance overhead of counters (if many configured categories).
+	//
+	// But the naming, and the labels, of the counter, are generic to allow
+	// counting additional requests types or status codes in the future. Without
+	// having to rename the counter and get issues with non continous history of
+	// metrics.
+
+	counterIncomingReqs := promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bazel_remote_incoming_requests_total",
+			Help: "The number of incoming HTTP and gRPC request. Currently only AC requests",
+		},
+		labels)
+
+	m := &metrics{
+		categoryValues:      categoryValues,
+		counterIncomingReqs: counterIncomingReqs,
+		parent:              parent,
+	}
+	return m
+}
+
+func (m *metrics) Put(kind cache.EntryKind, hash string, size int64, r io.Reader, context cache.RequestContext) error {
+	err := m.parent.Put(kind, hash, size, r, context)
+
+	if kind == cache.AC {
+		var status string
+		if err != nil {
+			status = statusError
+		} else {
+			status = statusOK
+		}
+		m.incrementRequests(kind, methodPut, status, context)
+	}
+
+	return err
+}
+
+func (m *metrics) Get(kind cache.EntryKind, hash string, size int64, context cache.RequestContext) (io.ReadCloser, int64, error) {
+	rc, sizeBytes, err := m.parent.Get(kind, hash, size, context)
+
+	if kind == cache.AC {
+		var status string
+		if err != nil {
+			status = statusError
+		} else if rc == nil {
+			status = statusNotFound
+		} else {
+			status = statusOK
+		}
+		m.incrementRequests(kind, methodGet, status, context)
+	}
+
+	return rc, sizeBytes, err
+}
+
+func (m *metrics) Contains(kind cache.EntryKind, hash string, size int64, context cache.RequestContext) (bool, int64) {
+	ok, sizeBytes := m.parent.Contains(kind, hash, size, context)
+
+	if kind == cache.AC {
+		var status string
+		if ok {
+			status = statusOK
+		} else {
+			status = statusNotFound
+		}
+		m.incrementRequests(kind, methodContains, status, context)
+	}
+
+	return ok, sizeBytes
+}
+
+func (m *metrics) GetValidatedActionResult(hash string, context cache.RequestContext) (*pb.ActionResult, []byte, error) {
+	ac, data, err := m.parent.GetValidatedActionResult(hash, context)
+
+	var status string
+	if err != nil {
+		status = statusError
+	} else if ac == nil {
+		status = statusNotFound
+	} else {
+		status = statusOK
+	}
+	m.incrementRequests(cache.AC, methodGet, status, context)
+
+	return ac, data, err
+}
+
+func getLabelValueFromHeaderValues(headerValues []string, allowedValues map[string]struct{}) string {
+	if len(headerValues) == 0 {
+		return "" // No header for this label
+	}
+	for _, headerValue := range headerValues {
+		// Prometheus only allows one value per label.
+		// Pick the first allowed header value we find.
+		if _, ok := allowedValues[headerValue]; ok {
+			return headerValue
+		}
+	}
+
+	// The values found in the header has not been listed in
+	// the configuration file. Represent them as "other".
+	//
+	// Listening allowed values is an attempt to avoid polluting
+	// prometheus with too many different time series.
+	//
+	// https://prometheus.io/docs/practices/naming/ warns about:
+	//
+	//   "CAUTION: Remember that every unique combination of key-value
+	//   label pairs represents a new time series, which can dramatically
+	//   increase the amount of data stored. Do not use labels to store
+	//   dimensions with high cardinality (many different label values),
+	//   such as user IDs, email addresses, or other unbounded sets of
+	//   values."
+	//
+	// It would have been nice if bazel-remote could reload the set
+	// of allowed values from updated configuration file, by
+	// SIGHUP signal instead of having to restart bazel-remote.
+	return "other"
+}
+
+func (m *metrics) incrementRequests(kind cache.EntryKind, method string, status string, reqCtx cache.RequestContext) {
+	labels := make(prometheus.Labels)
+	labels["method"] = method
+	labels["status"] = status
+	labels["kind"] = kind.String()
+
+	for labelName := range m.categoryValues {
+		labels[labelName] = getLabelValueFromHeaderValues(reqCtx.GetHeader(labelName), m.categoryValues[labelName])
+	}
+
+	m.counterIncomingReqs.With(labels).Inc()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,11 @@ type HTTPBackendConfig struct {
 	BaseURL string `yaml:"url"`
 }
 
+// Metrics stores configuration for prometheus metrics.
+type Metrics struct {
+	Categories map[string][]string `yaml:"categories"`
+}
+
 // Config holds the top-level configuration for bazel-remote.
 type Config struct {
 	Host                        string                    `yaml:"host"`
@@ -55,6 +60,7 @@ type Config struct {
 	DisableGRPCACDepsCheck      bool                      `yaml:"disable_grpc_ac_deps_check"`
 	EnableACKeyInstanceMangling bool                      `yaml:"enable_ac_key_instance_mangling"`
 	EnableEndpointMetrics       bool                      `yaml:"enable_endpoint_metrics"`
+	Metrics                     *Metrics                  `yaml:"metrics"`
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
@@ -73,6 +79,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 	disableGRPCACDepsCheck bool,
 	enableACKeyInstanceMangling bool,
 	enableEndpointMetrics bool,
+	metrics *Metrics,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration) (*Config, error) {
@@ -95,6 +102,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 		DisableGRPCACDepsCheck:      disableGRPCACDepsCheck,
 		EnableACKeyInstanceMangling: enableACKeyInstanceMangling,
 		EnableEndpointMetrics:       enableEndpointMetrics,
+		Metrics:                     metrics,
 		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -575,7 +575,7 @@ func TestGrpcByteStreamDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, sz, err := diskCache.Get(cache.CAS, testBlobHash, testBlobSize)
+	_, sz, err := diskCache.Get(cache.CAS, testBlobHash, testBlobSize, nil)
 	if err != nil {
 		t.Fatalf("get error: %v\n", err)
 	}

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -36,8 +36,7 @@ func TestDownloadFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, blobSize, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
-
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	req, err := http.NewRequest("GET", "/cas/"+hash, bytes.NewReader([]byte{}))
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +98,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 1000*1024, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -157,7 +156,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	numWorkers := 100
 
 	c := disk.New(cacheDir, int64(len(data)*numWorkers), nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -203,7 +202,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -245,7 +244,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	c := disk.New(cacheDir, 2048, nil)
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -302,7 +301,7 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	c := disk.New(cacheDir, 2048, nil)
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -325,7 +324,7 @@ func TestStatusPage(t *testing.T) {
 	}
 
 	c := disk.New(cacheDir, 2048, nil)
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -466,7 +465,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 	emptyCache := disk.New(cacheDir, 1024, nil)
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(emptyCache, emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))


### PR DESCRIPTION
This is a draft, not ready to be merged. I wait with test cases until
getting feedback about the main functionality.

Same functionality as in https://github.com/buchgr/bazel-remote/pull/350

 - Prometheus counter for cache hit ratio of only AC requests.

 - Support for prometheus labels based on custom HTTP and gRPC headers.

but implemented in an alternative way:

 - disk.io implements two interfaces: cache.CasAcCache, cache.Stats

 - cache.metricsdecorator is decorator for cache.CasAcCache and
   provides prometheus metrics.

Pros with this alternative implementation:

 - Should allow non-prometheus metrics as requested in
   https://github.com/buchgr/bazel-remote/issues/355

 - Avoid the question about if the counters should be placed in
   disk.go or http.go/grpc*.go. If placing in disk.go, there are
   issues about how to avoid incrementing counter twice for the
   same request (both in Get and in GetValidatedActionResult)
   and at the same time count found AC but missing CAS, as cache miss.

 - Makes headers available also for logic in disk.go, which could be
   useful for other functionality in the future.

 - Metrics can be separated from logging, and still not require
   injecting counter increment invocations in tons of places.
   Incrementing from a few well defined places minimize the risk
   for bugs in the metrics.