### PR TITLE
support mTLS for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,21 @@ $ docker run -v /path/to/cache/dir:/data \
 	--htpasswd_file /etc/bazel-remote/htpasswd --max_size=5
 ```
 
+You can also enforce authentication with client certificates by passing in a `tls_ca_file`:
+
+```bash
+$ docker run -v /path/to/cache/dir:/data \
+   -v /path/to/certificate_authority:/etc/bazel-remote/ca_cert \
+	-v /path/to/server_cert:/etc/bazel-remote/server_cert \
+	-v /path/to/server_key:/etc/bazel-remote/server_key \
+	-p 9090:8080 -p 9092:9092 buchgr/bazel-remote-cache \
+	--tls_enabled=true \
+   --tls_ca_file=/etc/bazel-remote/ca_cert \
+	--tls_cert_file=/etc/bazel-remote/server_cert \
+	--tls_key_file=/etc/bazel-remote/server_key \
+   --max_size=5
+```
+
 ### Profiling
 
 To enable pprof profiling, specify a port with `--profile_port`.

--- a/README.md
+++ b/README.md
@@ -304,19 +304,19 @@ $ docker run -v /path/to/cache/dir:/data \
 	--htpasswd_file /etc/bazel-remote/htpasswd --max_size=5
 ```
 
-You can also enforce authentication with client certificates by passing in a `tls_ca_file`:
+If you prefer not using `.htpasswd` files it is also possible to authenticate with mTLS (also can be known as "authenticating client certificates"). You can do this by passing in the the cert/key the server should use, as well as the certificate authority that signed the client certificates:
 
 ```bash
 $ docker run -v /path/to/cache/dir:/data \
-   -v /path/to/certificate_authority:/etc/bazel-remote/ca_cert \
-	-v /path/to/server_cert:/etc/bazel-remote/server_cert \
-	-v /path/to/server_key:/etc/bazel-remote/server_key \
-	-p 9090:8080 -p 9092:9092 buchgr/bazel-remote-cache \
-	--tls_enabled=true \
-   --tls_ca_file=/etc/bazel-remote/ca_cert \
-	--tls_cert_file=/etc/bazel-remote/server_cert \
-	--tls_key_file=/etc/bazel-remote/server_key \
-   --max_size=5
+  -v /path/to/certificate_authority:/etc/bazel-remote/ca_cert \
+  -v /path/to/server_cert:/etc/bazel-remote/server_cert \
+  -v /path/to/server_key:/etc/bazel-remote/server_key \
+  -p 9090:8080 -p 9092:9092 buchgr/bazel-remote-cache \
+  --tls_enabled=true \
+  --tls_ca_file=/etc/bazel-remote/ca_cert \
+  --tls_cert_file=/etc/bazel-remote/server_cert \
+  --tls_key_file=/etc/bazel-remote/server_key \
+  --max_size=5
 ```
 
 ### Profiling

--- a/config/config.go
+++ b/config/config.go
@@ -180,8 +180,9 @@ func validateConfig(c *Config) error {
 	}
 
 	if c.TLSCaFile != "" && (c.TLSCertFile == "" || c.TLSKeyFile == "") {
-		return errors.New("When enabling mTLS one must specify a: 'tls_ca_file' " +
-			"as well as 'tls_cert_file', and 'tls_key_file'")
+		return errors.New("When enabling mTLS (authenticating client " +
+			"certificates) the server must have it's own 'tls_key_file' " +
+			"and 'tls_cert_file' specified.")
 	}
 
 	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil && c.S3CloudStorage != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	Dir                         string                    `yaml:"dir"`
 	MaxSize                     int                       `yaml:"max_size"`
 	HtpasswdFile                string                    `yaml:"htpasswd_file"`
+	TLSCaFile                   string                    `yaml:"tls_ca_file"`
 	TLSCertFile                 string                    `yaml:"tls_cert_file"`
 	TLSKeyFile                  string                    `yaml:"tls_key_file"`
 	S3CloudStorage              *S3CloudStorageConfig     `yaml:"s3_proxy,omitempty"`
@@ -69,6 +70,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 	htpasswdFile string,
 	maxQueuedUploads int,
 	numUploaders int,
+	tlsCaFile string,
 	tlsCertFile string,
 	tlsKeyFile string,
 	idleTimeout time.Duration,
@@ -91,6 +93,7 @@ func New(dir string, maxSize int, host string, port int, grpcPort int,
 		HtpasswdFile:                htpasswdFile,
 		MaxQueuedUploads:            maxQueuedUploads,
 		NumUploaders:                numUploaders,
+		TLSCaFile:                   tlsCaFile,
 		TLSCertFile:                 tlsCertFile,
 		TLSKeyFile:                  tlsKeyFile,
 		S3CloudStorage:              s3,
@@ -174,6 +177,11 @@ func validateConfig(c *Config) error {
 	if (c.TLSCertFile != "" && c.TLSKeyFile == "") || (c.TLSCertFile == "" && c.TLSKeyFile != "") {
 		return errors.New("When enabling TLS one must specify both " +
 			"'tls_key_file' and 'tls_cert_file'")
+	}
+
+	if c.TLSCaFile != "" && (c.TLSCertFile == "" || c.TLSKeyFile == "") {
+		return errors.New("When enabling mTLS one must specify a: 'tls_ca_file' " +
+			"as well as 'tls_cert_file', and 'tls_key_file'")
 	}
 
 	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil && c.S3CloudStorage != nil {

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "tls_ca_file",
 			Value:   "",
-			Usage:   "Path to a pem encoded certificate authority file.",
+			Usage:   "Optional. Enables mTLS (authenticating client certificates), should be the certificate authority that signed the client certificates.",
 			EnvVars: []string{"BAZEL_REMOTE_TLS_CA_FILE"},
 		},
 		&cli.StringFlag{
@@ -396,8 +396,6 @@ func main() {
 			tlsConfig = &tls.Config{
 				Certificates: []tls.Certificate{readCert},
 			}
-		} else {
-			tlsConfig = nil
 		}
 
 		mux := http.NewServeMux()


### PR DESCRIPTION
fixes #356 

this adds in support for specifying a `--tls_ca_file` which when provided will validate client certificates against that particular authority.

I originally thought about splitting the `--tls_ca_file` option into two (e.g. having an: `--mtls` flag, that actually enforced the client certificates), but I figured if this is the only use case for specifying a `--tls_ca_file` (which it seems right now this is true for this project, though not in general) best to not add an extra option. If you'd like though I can always go back, and add it in.

This seems to pass all tests locally. I've also run just locally on my machine with self signed certs:

```
./bazel-remote --tls_ca_file ca.pem --tls_cert_file server.pem --tls_key_file server.key  --dir bazel-remote-tmp-cache/ --max_size 1
```

The Endpoint is properly authenticated:

```
# HTTP 1 gives a clearer error message
$ curl --httpv1.1 --cacert ca.pem -sSL -i https://localhost:8080/status
curl: (56) OpenSSL SSL_read: error:14094412:SSL routines:ssl3_read_bytes:sslv3 alert bad certificate, errno 0
$ curl --cacert ca.pem --cert basic-user.pem --key basic-user.key -sSL -i https://localhost:8080/status
HTTP/2 200 
content-type: application/json
content-length: 179
date: Tue, 29 Sep 2020 17:56:13 GMT

{
 "CurrSize": 377389094,
 "ReservedSize": 0,
 "MaxSize": 10737418240000,
 "NumFiles": 9296,
 "ServerTime": 1601402173,
 "GitCommit": "bfe94a99e2c765cffe6000a51443140f6534282d"
}
```

And with no ca certificate, but a cert/key it just accepts any user as it does now:

```
$ curl --cacert ca.pem -sSL -i https://localhost:8080/status
HTTP/2 200 content-type: application/json
content-length: 179
date: Tue, 29 Sep 2020 17:57:59 GMT

{
 "CurrSize": 377389094,
 "ReservedSize": 0,
 "MaxSize": 10737418240000,
 "NumFiles": 9296,
 "ServerTime": 1601402279,
 "GitCommit": "bfe94a99e2c765cffe6000a51443140f6534282d"
}
```