### PR TITLE
Introduce `metric.Collector` interface

### DIFF
--- a/cache/gcsproxy/gcsproxy.go
+++ b/cache/gcsproxy/gcsproxy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/buchgr/bazel-remote/cache"
 	"github.com/buchgr/bazel-remote/cache/httpproxy"
+	"github.com/buchgr/bazel-remote/metric"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -17,7 +18,7 @@ import (
 
 // New creates a cache that proxies requests to Google Cloud Storage.
 func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
-	accessLogger cache.Logger, errorLogger cache.Logger, numUploaders, maxQueuedUploads int) (cache.Proxy, error) {
+	accessLogger cache.Logger, errorLogger cache.Logger, numUploaders, maxQueuedUploads int, collector metric.Collector) (cache.Proxy, error) {
 	var remoteClient *http.Client
 	var err error
 
@@ -53,5 +54,5 @@ func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
 		Path:   bucket,
 	}
 
-	return httpproxy.New(&baseURL, remoteClient, accessLogger, errorLogger, numUploaders, maxQueuedUploads), nil
+	return httpproxy.New(&baseURL, remoteClient, accessLogger, errorLogger, numUploaders, maxQueuedUploads, collector), nil
 }

--- a/metric/collector.go
+++ b/metric/collector.go
@@ -1,0 +1,34 @@
+package metric
+
+// Counter is a standard metric counter
+type Counter interface {
+	Inc()
+	Add(value float64)
+}
+
+type noop struct{}
+
+func (c *noop) Inc()              {}
+func (c *noop) Set(v float64)     {}
+func (c *noop) Add(value float64) {}
+
+// NoOpCounter is a Counter that does nothing
+func NoOpCounter() Counter {
+	return &noop{}
+}
+
+// Gauge is a standard metric gauge
+type Gauge interface {
+	Set(value float64)
+}
+
+// NoOpGauge is a Gauge that does nothing
+func NoOpGauge() Gauge {
+	return &noop{}
+}
+
+// Collector is an interface for creating metrics
+type Collector interface {
+	NewCounter(name string) Counter
+	NewGuage(name string) Gauge
+}

--- a/metric/prometheus/prometheus.go
+++ b/metric/prometheus/prometheus.go
@@ -52,13 +52,13 @@ type collector struct{}
 func (c *collector) NewCounter(name string) metric.Counter {
 	return promauto.NewCounter(prometheus.CounterOpts{
 		Name: name,
-		Help: help["name"],
+		Help: help[name],
 	})
 }
 
 func (c *collector) NewGuage(name string) metric.Gauge {
 	return promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "bazel_remote_disk_cache_size_bytes",
-		Help: help["name"],
+		Help: help[name],
 	})
 }

--- a/metric/prometheus/prometheus.go
+++ b/metric/prometheus/prometheus.go
@@ -15,6 +15,19 @@ import (
 // durationBuckets is the buckets used for Prometheus histograms in seconds.
 var durationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
 
+// map metric names to their help message
+var help = map[string]string{
+	"bazel_remote_disk_cache_hits":                    "The total number of disk backend cache hits",
+	"bazel_remote_disk_cache_misses":                  "The total number of disk backend cache misses",
+	"bazel_remote_disk_cache_size_bytes":              "The current number of bytes in the disk backend",
+	"bazel_remote_disk_cache_evicted_bytes_total":     "The total number of bytes evicted from disk backend, due to full cache",
+	"bazel_remote_disk_cache_overwritten_bytes_total": "The total number of bytes removed from disk backend, due to put of already existing key",
+	"bazel_remote_http_cache_hits":                    "The total number of HTTP backend cache hits",
+	"bazel_remote_http_cache_misses":                  "The total number of HTTP backend cache misses",
+	"bazel_remote_s3_cache_hits":                      "The total number of s3 backend cache hits",
+	"bazel_remote_s3_cache_misses":                    "The total number of s3 backend cache misses",
+}
+
 // NewCollector returns a prometheus backed collector
 func NewCollector() metric.Collector {
 	return &collector{}
@@ -39,13 +52,13 @@ type collector struct{}
 func (c *collector) NewCounter(name string) metric.Counter {
 	return promauto.NewCounter(prometheus.CounterOpts{
 		Name: name,
-		Help: "The total number of disk backend cache hits",
+		Help: help["name"],
 	})
 }
 
 func (c *collector) NewGuage(name string) metric.Gauge {
 	return promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "bazel_remote_disk_cache_size_bytes",
-		Help: "The current number of bytes in the disk backend",
+		Help: help["name"],
 	})
 }

--- a/metric/prometheus/prometheus.go
+++ b/metric/prometheus/prometheus.go
@@ -1,0 +1,51 @@
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/buchgr/bazel-remote/metric"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	httpmetrics "github.com/slok/go-http-metrics/metrics/prometheus"
+	"github.com/slok/go-http-metrics/middleware"
+	middlewarestd "github.com/slok/go-http-metrics/middleware/std"
+)
+
+// durationBuckets is the buckets used for Prometheus histograms in seconds.
+var durationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
+
+// NewCollector returns a prometheus backed collector
+func NewCollector() metric.Collector {
+	return &collector{}
+}
+
+// WrapEndpoints attaches the prometheus metrics endpoints to a mux
+func WrapEndpoints(mux *http.ServeMux, cache http.HandlerFunc, status http.HandlerFunc) {
+	metricsMdlw := middleware.New(middleware.Config{
+		Recorder: httpmetrics.NewRecorder(httpmetrics.Config{
+			DurationBuckets: durationBuckets,
+		}),
+	})
+	mux.Handle("/metrics", middlewarestd.Handler("metrics", metricsMdlw, promhttp.Handler()))
+	mux.Handle("/status", middlewarestd.Handler("status", metricsMdlw, http.HandlerFunc(status)))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		middlewarestd.Handler(r.Method, metricsMdlw, http.HandlerFunc(cache)).ServeHTTP(w, r)
+	})
+}
+
+type collector struct{}
+
+func (c *collector) NewCounter(name string) metric.Counter {
+	return promauto.NewCounter(prometheus.CounterOpts{
+		Name: name,
+		Help: "The total number of disk backend cache hits",
+	})
+}
+
+func (c *collector) NewGuage(name string) metric.Gauge {
+	return promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "bazel_remote_disk_cache_size_bytes",
+		Help: "The current number of bytes in the disk backend",
+	})
+}


### PR DESCRIPTION
This commit wraps the standard Prometheus metrics in interfaces. The idea is to support different ways to collect metrics while keeping Prometheus the default. I haven't addressed the gRPC metrics collection yet, but it's on my radar. 

I'm opening this PR to gather feedback and address the ongoing conversation in #355. Happy to discuss anything and everything!