### PR TITLE
[disk] return an error from disk.New instead of exiting

### DIFF
--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -103,7 +103,10 @@ func TestEverything(t *testing.T) {
 
 	proxyCache := New(url, &http.Client{}, accessLogger, errorLogger, 100, 10000)
 	diskCacheSize := int64(len(casData) + 1024)
-	diskCache := disk.New(cacheDir, diskCacheSize, proxyCache)
+	diskCache, err := disk.New(cacheDir, diskCacheSize, proxyCache)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// PUT two different values with the same key in ac and cas.
 
@@ -226,7 +229,10 @@ func TestEverything(t *testing.T) {
 	cacheDir2 := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir2)
 
-	diskCache = disk.New(cacheDir2, diskCacheSize, proxyCache)
+	diskCache, err = disk.New(cacheDir2, diskCacheSize, proxyCache)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, _, numItems := diskCache.Stats()
 	if numItems != 0 {

--- a/main.go
+++ b/main.go
@@ -357,7 +357,10 @@ func main() {
 			proxyCache = s3proxy.New(c.S3CloudStorage, accessLogger, errorLogger, c.NumUploaders, c.MaxQueuedUploads)
 		}
 
-		diskCache := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache)
+		diskCache, err := disk.New(c.Dir, int64(c.MaxSize)*1024*1024*1024, proxyCache)
+		if err != nil {
+			log.Fatal(err)
+		}
 
 		var tlsConfig *tls.Config
 		if len(c.TLSCaFile) != 0 {

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -69,7 +69,11 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(dir)
 
-	diskCache = disk.New(dir, int64(10*maxChunkSize), nil)
+	diskCache, err = disk.New(dir, int64(10*maxChunkSize), nil)
+	if err != nil {
+		fmt.Println("Test setup failed")
+		os.Exit(1)
+	}
 
 	accessLogger := testutils.NewSilentLogger()
 	errorLogger := testutils.NewSilentLogger()

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -35,7 +35,10 @@ func TestDownloadFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := disk.New(cacheDir, blobSize, nil)
+	c, err := disk.New(cacheDir, blobSize, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 
 	req, err := http.NewRequest("GET", "/cas/"+hash, bytes.NewReader([]byte{}))
@@ -98,7 +101,10 @@ func TestUploadFilesConcurrently(t *testing.T) {
 		requests[i] = r
 	}
 
-	c := disk.New(cacheDir, 1000*1024, nil)
+	c, err := disk.New(cacheDir, 1000*1024, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
@@ -156,7 +162,10 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 
 	numWorkers := 100
 
-	c := disk.New(cacheDir, int64(len(data)*numWorkers), nil)
+	c, err := disk.New(cacheDir, int64(len(data)*numWorkers), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
@@ -202,7 +211,10 @@ func TestUploadCorruptedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := disk.New(cacheDir, 2048, nil)
+	c, err := disk.New(cacheDir, 2048, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
@@ -242,7 +254,10 @@ func TestUploadEmptyActionResult(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := disk.New(cacheDir, 2048, nil)
+	c, err := disk.New(cacheDir, 2048, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	validate := true
 	mangle := false
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
@@ -299,7 +314,10 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 		t.Fatal(err)
 	}
 
-	c := disk.New(cacheDir, 2048, nil)
+	c, err := disk.New(cacheDir, 2048, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	validate := true
 	mangle := false
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
@@ -324,7 +342,10 @@ func TestStatusPage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := disk.New(cacheDir, 2048, nil)
+	c, err := disk.New(cacheDir, 2048, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
@@ -464,7 +485,10 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(cacheDir)
-	emptyCache := disk.New(cacheDir, 1024, nil)
+	emptyCache, err := disk.New(cacheDir, 1024, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
 	// create a fake http.Request


### PR DESCRIPTION
This makes test failures have nicer error messages.