### PR TITLE
disk test cleanup

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -402,7 +402,7 @@ func (c *Cache) commit(key string, tempfile string, finalPath string, reservedSi
 	return unreserve, removeTempfile, nil
 }
 
-// Return a non-nil *os.File and non-negative size if the item is available
+// Return a non-nil io.ReadCloser and non-negative size if the item is available
 // locally, and a boolean that indicates if the item is not available locally
 // but that we can try the proxy backend.
 func (c *Cache) availableOrTryProxy(key string, size int64, blobPath string) (rc io.ReadCloser, foundSize int64, tryProxy bool, err error) {

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -32,35 +31,6 @@ func tempDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return dir
-}
-
-func checkItems(cache *Cache, expSize int64, expNum int) error {
-	if cache.lru.Len() != expNum {
-		return fmt.Errorf("expected %d files in the cache, found %d", expNum, cache.lru.Len())
-	}
-	if cache.lru.TotalSize() != expSize {
-		return fmt.Errorf("expected %d bytes in the cache, found %d", expSize, cache.lru.TotalSize())
-	}
-
-	numFiles := 0
-	err := filepath.Walk(cache.dir, func(name string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			numFiles++
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if numFiles != expNum {
-		return fmt.Errorf("expected %d files on disk, found %d", expNum, numFiles)
-	}
-
-	return nil
 }
 
 const KEY = "a-key"

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -115,51 +115,6 @@ func TestCacheBasics(t *testing.T) {
 	}
 }
 
-func TestCacheEviction(t *testing.T) {
-	cacheDir := tempDir(t)
-	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 10, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedSizesNumItems := []struct {
-		expSize int64
-		expNum  int
-	}{
-		{0, 1},  // 0
-		{1, 2},  // 0, 1
-		{3, 3},  // 0, 1, 2
-		{6, 4},  // 0, 1, 2, 3
-		{10, 5}, // 0, 1, 2, 3, 4
-		{9, 2},  // 4, 5
-		{6, 1},  // 6
-		{7, 1},  // 7
-	}
-
-	for i, thisExp := range expectedSizesNumItems {
-		strReader := strings.NewReader(strings.Repeat("a", i))
-
-		// Suitably-sized, unique key for these testcases:
-		key := fmt.Sprintf("%0*d", sha256HashStrSize, i)
-		if len(key) != sha256.Size*2 {
-			t.Fatalf("invalid testcase- key length should be %d, not %d: %s",
-				sha256.Size*2, len(key), key)
-		}
-
-		err := testCache.Put(cache.AC, key, int64(i),
-			ioutil.NopCloser(strReader))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = checkItems(testCache, thisExp.expSize, thisExp.expNum)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 func TestCachePutWrongSize(t *testing.T) {
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -237,30 +237,39 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 
 	// The proxyStub contains the digest {contentsHash, contentsLength}.
 
+	if testCache.lru.Len() != 0 {
+		t.Fatalf("Expected to start with an empty disk cache, found %d items",
+			testCache.lru.Len())
+	}
+
 	found, _ = testCache.Contains(cache.CAS, contentsHash, contentsLength+1)
 	if found {
-		t.Error("Expected not found, due to size being different")
+		t.Fatal("Expected not found, due to size being different")
 	}
 
 	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, contentsLength+1)
 	if rdr != nil {
-		t.Error("Expected not found, due to size being different")
+		t.Fatal("Expected not found, due to size being different")
 	}
-	if err := checkItems(testCache, 0, 0); err != nil {
-		t.Fatal(err)
+
+	if testCache.lru.Len() != 0 {
+		t.Fatalf("Expected cache to be empty at this point, found %d items",
+			testCache.lru.Len())
 	}
 
 	found, _ = testCache.Contains(cache.CAS, contentsHash, -1)
 	if !found {
-		t.Error("Expected found, when unknown size")
+		t.Fatal("Expected found, when unknown size")
 	}
 
 	rdr, _, _ = testCache.Get(cache.CAS, contentsHash, -1)
 	if rdr == nil {
-		t.Error("Expected found, when unknown size")
+		t.Fatal("Expected found, when unknown size")
 	}
-	if err := checkItems(testCache, contentsLength, 1); err != nil {
-		t.Fatal(err)
+
+	if testCache.lru.Len() != 1 {
+		t.Fatalf("Expected one item to be in the cache at this point, found %d items",
+			testCache.lru.Len())
 	}
 }
 


### PR DESCRIPTION
This is prep work for the experimental compressed-blobs REAPI feature. We should refactor our disk cache tests so they don't assume things that the (future) implementation won't enforce (in particular blob size at the disk cache API level will in general not match the blob size on disk, due to compression). Some of these tests can still be performed against the LRU API, however.