### PR TITLE
Specify oauth scopes for service account keys

### DIFF
--- a/cache/gcsproxy/gcsproxy.go
+++ b/cache/gcsproxy/gcsproxy.go
@@ -33,7 +33,8 @@ func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
 			err = fmt.Errorf("Failed to read Google Credentials file '%s': %v", jsonCredentialsFile, err)
 			return nil, err
 		}
-		config, err := google.CredentialsFromJSON(oauth2.NoContext, jsonConfig)
+		config, err := google.CredentialsFromJSON(oauth2.NoContext, jsonConfig,
+			"https://www.googleapis.com/auth/devstorage.read_write")
 		if err != nil {
 			err = fmt.Errorf("The provided Google Credentials file '%s' couldn't be parsed: %v",
 				jsonCredentialsFile, err)

--- a/cache/gcsproxy/gcsproxy.go
+++ b/cache/gcsproxy/gcsproxy.go
@@ -23,7 +23,7 @@ func New(bucket string, useDefaultCredentials bool, jsonCredentialsFile string,
 
 	if useDefaultCredentials {
 		remoteClient, err = google.DefaultClient(oauth2.NoContext,
-			"https://www.googleapis.com/auth/cloud-platform")
+			"https://www.googleapis.com/auth/devstorage.read_write")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When using bazel-remote as a proxy for a GCS bucket, and using a json credentials file for a service account, requests to access the GCS bucket fail with errors such as:
```
Get "https://storage.googleapis.com/...":
oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_scope","error_description":"Invalid OAuth scope or ID token audience provided."}
```
These errors are fixed by specifying the desired oauth scopes when reading the JSON service key.