### PR TITLE
Add new endpoint_metrics_duration_buckets config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ host: localhost
 # If set to true, enable metrics for each HTTP/gRPC endpoint.
 #enable_endpoint_metrics: false
 
+# Specify a custom list of histogram buckets for endpoint request duration metrics
+#endpoint_metrics_duration_buckets: [.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320]
+
 # At most one of the proxy backends can be selected:
 #
 # If this is 0, proxy backends won't upload blobs.

--- a/main.go
+++ b/main.go
@@ -46,9 +46,6 @@ const (
 // is set through linker options.
 var gitCommit string
 
-// durationBuckets is the buckets used for Prometheus histograms in seconds.
-var durationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
-
 func main() {
 
 	log.SetFlags(logFlags)
@@ -435,7 +432,7 @@ func main() {
 		if c.EnableEndpointMetrics {
 			metricsMdlw := middleware.New(middleware.Config{
 				Recorder: httpmetrics.NewRecorder(httpmetrics.Config{
-					DurationBuckets: durationBuckets,
+					DurationBuckets: c.MetricsDurationBuckets,
 				}),
 			})
 			mux.Handle("/metrics", middlewarestd.Handler("metrics", metricsMdlw, promhttp.Handler()))
@@ -464,7 +461,7 @@ func main() {
 				if c.EnableEndpointMetrics {
 					streamInterceptors = append(streamInterceptors, grpc_prometheus.StreamServerInterceptor)
 					unaryInterceptors = append(unaryInterceptors, grpc_prometheus.UnaryServerInterceptor)
-					grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(durationBuckets))
+					grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(c.MetricsDurationBuckets))
 				}
 
 				if tlsConfig != nil {


### PR DESCRIPTION
This allows people to configure a more suitable histogram range for their deployment. If the option is not specified, the default remains the same as the current values.

Fixes #389.