### PR TITLE
[ci] automatically build and upload binaries when publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: create release binaries
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  linux:
+    name: create linux binary
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: build
+        run: |
+          set -eu
+          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-linux-amd64
+          chmod +x bazelisk-linux-amd64
+          ./bazelisk-linux-amd64 build //:bazel-remote
+          ./bazelisk-linux-amd64 run --run_under "cp -f " //:bazel-remote $(pwd)/bazel-remote
+      - name: get release URL
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: get release version
+        id: release_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      - name: upload
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: bazel-remote
+          asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-linux-x86_64
+          asset_content_type: application/octet-stream
+
+  mac:
+    name: create mac binary
+    runs-on: macos-10.15
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build
+        run: |
+          set -eu
+          wget https://github.com/bazelbuild/bazelisk/releases/download/v1.7.5/bazelisk-darwin-amd64
+          chmod +x bazelisk-darwin-amd64
+          ./bazelisk-darwin-amd64 build //:bazel-remote
+          ./bazelisk-darwin-amd64 run --run_under "cp -f " //:bazel-remote $(pwd)/bazel-remote
+      - name: get release URL
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: get release version
+        id: release_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
+      - name: upload
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: bazel-remote
+          asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-darwin-x86_64
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
It is not obvious how to do this securely with bazelci / buildkite, but it is easy with a github action.