### PR TITLE
[disk] improve disk usage estimates by rounding file sizes up to 4kb blocks

### DIFF
--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -46,7 +46,7 @@ func TestCacheBasics(t *testing.T) {
 	itemSize := int64(256)
 
 	// Add some overhead for likely CAS blob storage expansion.
-	cacheSize := int64(itemSize * 2)
+	cacheSize := int64(itemSize*2 + BlockSize)
 
 	testCache, err := New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestCacheBasics(t *testing.T) {
 func TestCachePutWrongSize(t *testing.T) {
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 100, "zstd", nil)
+	testCache, err := New(cacheDir, BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestCacheGetContainsWrongSize(t *testing.T) {
 
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 100, "zstd", nil)
+	testCache, err := New(cacheDir, BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 100, "zstd", new(proxyStub))
+	testCache, err := New(cacheDir, BlockSize, "zstd", new(proxyStub))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestOverwrite(t *testing.T) {
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
 
-	testCache, err := New(cacheDir, 100, "zstd", nil)
+	testCache, err := New(cacheDir, BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -391,7 +391,7 @@ func TestCacheExistingFiles(t *testing.T) {
 	}
 
 	// Add some overhead for likely CAS blob storage expansion.
-	const cacheSize = 1024
+	const cacheSize = BlockSize * 5
 
 	testCache, err := New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {
@@ -448,7 +448,7 @@ func TestCacheExistingFiles(t *testing.T) {
 func TestCacheBlobTooLarge(t *testing.T) {
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 100, "zstd", nil)
+	testCache, err := New(cacheDir, BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +474,7 @@ func TestCacheBlobTooLarge(t *testing.T) {
 func TestCacheCorruptedCASBlob(t *testing.T) {
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCache, err := New(cacheDir, 1000, "zstd", nil)
+	testCache, err := New(cacheDir, BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -556,7 +556,7 @@ func TestMigrateFromOldDirectoryStructure(t *testing.T) {
 	}
 
 	// Add some overhead for likely CAS blob storage expansion.
-	const cacheSize = 2560 * 2
+	const cacheSize = 2560*2 + BlockSize*2
 
 	testCache, err := New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {
@@ -626,7 +626,7 @@ func TestLoadExistingEntries(t *testing.T) {
 	}
 
 	// Add some overhead for likely CAS blob storage expansion.
-	cacheSize := int64(blobSize * numBlobs * 2)
+	cacheSize := int64((blobSize + BlockSize) * numBlobs * 2)
 
 	testCache, err := New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {
@@ -664,7 +664,7 @@ func TestDistinctKeyspaces(t *testing.T) {
 	blobSize := 1024
 
 	// Add some overhead for likely CAS blob storage expansion.
-	cacheSize := int64(blobSize*3) * 2
+	cacheSize := int64((blobSize+BlockSize)*3) * 2
 
 	testCache, err := New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -113,7 +113,7 @@ func TestEverything(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diskCacheSize := int64(len(casData) + 2048)
+	diskCacheSize := int64(len(casData) + disk.BlockSize)
 	diskCache, err := disk.New(cacheDir, diskCacheSize, "zstd", proxyCache)
 	if err != nil {
 		t.Fatal(err)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -32,7 +32,7 @@ func TestDownloadFile(t *testing.T) {
 	data, hash := testutils.RandomDataAndHash(blobSize)
 
 	// Add some overhead for likely CAS blob storage expansion.
-	cacheSize := blobSize * 2
+	cacheSize := blobSize*2 + disk.BlockSize
 
 	c, err := disk.New(cacheDir, cacheSize, "zstd", nil)
 	if err != nil {
@@ -244,7 +244,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 
 	r := httptest.NewRequest("PUT", "/ac/"+hash, bytes.NewReader(data))
 
-	c, err := disk.New(cacheDir, 2048, "zstd", nil)
+	c, err := disk.New(cacheDir, disk.BlockSize, "zstd", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Before this change, we approximated disk usage by keeping a running total of the file lengths of every blob in the index. But most filesystems store files in sequences of fixed size blocks, typically with size 4kb, so our estimate of filesystem space usage has been significantly lower than the actual usage.

It we round file sizes up to the nearest 4kb boundary for the disk usage accounting, then we would have a better estimate. An even better estimate would check the number of 512 byte blocks reported by stat(2), but that would require an extra syscall after writing every file- so let's try this simple approximation first.

Resolves #397.