### PR TITLE
Fix race: Consume entire reader in WriteAndClose

### DIFF
--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -600,7 +600,7 @@ func WriteAndClose(r io.Reader, f *os.File, t CompressionType, hash string, size
 	}
 	h.chunkOffsets[nextChunk] = fileOffset
 
-	// Wait for EOF from the reader.
+	// Confirm that there is no data left to be read.
 	bytesAfter, err := io.ReadFull(r, uncompressedChunk)
 	if err == nil {
 		return -1, fmt.Errorf("expected %d bytes but got at least %d more", size, bytesAfter)

--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -600,6 +600,14 @@ func WriteAndClose(r io.Reader, f *os.File, t CompressionType, hash string, size
 	}
 	h.chunkOffsets[nextChunk] = fileOffset
 
+    // Wait for EOF from the reader.
+    bytesAfter, err := io.ReadFull(r, uncompressedChunk)
+    if err == nil {
+        return -1, fmt.Errorf("expected %s bytes but got at least %d more", size, bytesAfter)
+    } else if err != io.EOF {
+        return -1, err
+    }
+
 	actualHash := hex.EncodeToString(hasher.Sum(nil))
 	if actualHash != hash {
 		return -1, fmt.Errorf("checksums don't match. Expected %s, found %s",

--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -603,7 +603,7 @@ func WriteAndClose(r io.Reader, f *os.File, t CompressionType, hash string, size
 	// Wait for EOF from the reader.
 	bytesAfter, err := io.ReadFull(r, uncompressedChunk)
 	if err == nil {
-		return -1, fmt.Errorf("expected %s bytes but got at least %d more", size, bytesAfter)
+		return -1, fmt.Errorf("expected %d bytes but got at least %d more", size, bytesAfter)
 	} else if err != io.EOF {
 		return -1, err
 	}

--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -600,13 +600,13 @@ func WriteAndClose(r io.Reader, f *os.File, t CompressionType, hash string, size
 	}
 	h.chunkOffsets[nextChunk] = fileOffset
 
-    // Wait for EOF from the reader.
-    bytesAfter, err := io.ReadFull(r, uncompressedChunk)
-    if err == nil {
-        return -1, fmt.Errorf("expected %s bytes but got at least %d more", size, bytesAfter)
-    } else if err != io.EOF {
-        return -1, err
-    }
+	// Wait for EOF from the reader.
+	bytesAfter, err := io.ReadFull(r, uncompressedChunk)
+	if err == nil {
+		return -1, fmt.Errorf("expected %s bytes but got at least %d more", size, bytesAfter)
+	} else if err != io.EOF {
+		return -1, err
+	}
 
 	actualHash := hex.EncodeToString(hasher.Sum(nil))
 	if actualHash != hash {

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -99,18 +99,25 @@ func TestCachePutWrongSize(t *testing.T) {
 	content := "hello"
 	hash := hashStr(content)
 
-	err = testCache.Put(cache.AC, hash, int64(len(content)), strings.NewReader(content))
-	if err != nil {
-		t.Fatal("Expected success", err)
-	}
+	for _, kind := range []cache.EntryKind{cache.AC, cache.CAS, cache.RAW} {
+		err = testCache.Put(kind, hash, int64(len(content)), strings.NewReader(content))
+		if err != nil {
+			t.Fatal("Expected success", err)
+		}
 
-	err = testCache.Put(cache.AC, hash, int64(len(content))+1, strings.NewReader(content))
-	if err == nil {
-		t.Error("Expected error due to size being different")
-	}
-	err = testCache.Put(cache.AC, hash, int64(len(content))-1, strings.NewReader(content))
-	if err == nil {
-		t.Error("Expected error due to size being different")
+		err = testCache.Put(kind, hash, int64(len(content))+1, strings.NewReader(content))
+		if err == nil {
+			t.Error("Expected error due to size being different")
+		}
+
+		err = testCache.Put(kind, hash, int64(len(content))-1, strings.NewReader(content))
+		if err == nil {
+			t.Error("Expected error due to size being different")
+		}
+		err = testCache.Put(kind, hashStr(content[:len(content)-1]), int64(len(content))-1, strings.NewReader(content))
+		if err == nil {
+			t.Error("Expected error due to size being different")
+		}
 	}
 }
 


### PR DESCRIPTION
Noticed error on bazel side:
```
WARNING: Some artifacts failed be uploaded to the remote cache.
WARNING: Writing to Remote Cache:
BulkTransferException
```
And multiple errors on remote-cache side:
```
2021/03/13 01:57:49 GRPC BYTESTREAM WRITE INTERNAL ERROR instance/uploads/0098b6ad-4ecb-40c0-9348-622afbd38e0d/blobs/12593581821b68a00762613129d0998450759fc36c64014d9644bd6f895aeaff/302
```

The error leads to: https://github.com/buchgr/bazel-remote/blob/f0b31efdc1c6f0aa0d6db63443d54abbafbcb7d8/server/grpc_bytestream.go#L530

which can happen if `nil` err to `putResult` is sent before `recvResult` is closed, which can happen if this goroutine:
https://github.com/buchgr/bazel-remote/blob/f0b31efdc1c6f0aa0d6db63443d54abbafbcb7d8/server/grpc_bytestream.go#L432
finishes before recv stream is closed.


Will try to add test case slightly later.