### PR TITLE
[auth] add config setting to allow unauthenticated reads

### DIFF
--- a/.bazelci/basic-auth-tests.sh
+++ b/.bazelci/basic-auth-tests.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+set -v
+set -e
+set -u
+set -o pipefail
+
+SRC_ROOT=$(dirname "$0")/..
+SRC_ROOT=$(realpath "$SRC_ROOT")
+cd "$SRC_ROOT"
+
+HTTP_PORT=8089
+USER=topsecretusername
+PASS=topsecretpassword
+
+#export GRPC_GO_LOG_VERBOSITY_LEVEL=99
+#export GRPC_GO_LOG_SEVERITY_LEVEL=info
+
+tmpdir=$(mktemp -d bazel-remote-basic-auth-tests.XXXXXXX --tmpdir=${TMPDIR:-/tmp})
+
+[ -e bazel-remote ] || ./linux-build.sh
+
+# Generated with "htpasswd -b -c htpasswd $USER $PASS"
+echo 'topsecretusername:$apr1$Ke2kcK4W$EyueqiHyoqhwXcpiEGNyJ1' \
+	> "$tmpdir/htpasswd"
+
+echo "Starting bazel-remote, allowing unauthenticated reads..."
+./bazel-remote --dir "$tmpdir/cache" --max_size 1 --port "$HTTP_PORT" \
+	--htpasswd_file "$tmpdir/htpasswd" \
+	--allow_unauthenticated_reads > "$tmpdir/bazel-remote.log" 2>&1 &
+server_pid=$!
+
+# Wait a bit for the server start up...
+
+running=false
+for i in $(seq 1 20)
+do
+	sleep 1
+
+	if wget --inet4-only -d -O - --timeout=2 \
+		--http-user "$USER" --http-password "$PASS" \
+		"http://localhost:$HTTP_PORT/status"
+	then
+		running=true
+		break
+	fi
+done
+
+if [ "$running" != true ]
+then
+	echo "Error: bazel-remote took too long to start"
+	kill -9 $server_pid
+	exit 1
+fi
+
+# Authenticated read.
+wget --inet4-only -d -O - \
+	--http-user "$USER" --http-password "$PASS" \
+	http://localhost:$HTTP_PORT/status
+
+# Unauthenticated read.
+wget --inet4-only -d -O - http://localhost:$HTTP_PORT/status
+
+# Run without auth, expect readonly access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-reads-should-work
+
+# Run with auth, expect read-write access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-basic-auth-user "$USER" -basic-auth-pass "$PASS"
+
+# Authenticated build, populate the cache.
+bazel clean
+bazel build //:bazel-remote --remote_cache=grpc://$USER:$PASS@localhost:9092
+
+# Unauthenticated build, don't attempt to upload (gRPC).
+bazel clean
+bazel build //:bazel-remote --remote_cache=grpc://localhost:9092 \
+	--noremote_upload_local_results
+
+# Unauthenticated build, don't attempt to upload (HTTP).
+bazel clean
+bazel build //:bazel-remote --remote_cache=http://localhost:$HTTP_PORT \
+	--noremote_upload_local_results
+
+# Unauthenticated gRPC client, should fail to write, but the build
+# should succeed.
+bazel clean
+bazel build //:bazel-remote --remote_cache=grpc://localhost:9092 \
+	2>&1 | tee "$tmpdir/unauthenticated_write.log"
+
+grep -A 1 "WARNING: Writing to Remote Cache:" "$tmpdir/unauthenticated_write.log" | \
+	tr '\n' '|' > "$tmpdir/unauthenticated_write.log.singleline"
+if ! grep --silent "WARNING: Writing to Remote Cache:|BulkTransferException|" "$tmpdir/unauthenticated_write.log.singleline"
+then
+	# We seem to always have one cache miss with a rebuild.
+	# So we expect a single cache write attempt, and it should fail.
+	echo "Error: expected a warning when writing to the remote cache fails"
+	exit 1
+fi
+
+# Restart the server with authentication enabled but unauthenticated reads disabled.
+kill -9 $server_pid
+./bazel-remote --dir "$tmpdir/cache" --max_size 1 --port "$HTTP_PORT" \
+	--htpasswd_file "$tmpdir/htpasswd" > "$tmpdir/bazel-remote-authenticated.log" 2>&1 &
+server_pid=$!
+
+# Wait a bit for the server start up...
+
+running=false
+for i in $(seq 1 20)
+do
+	sleep 1
+
+	if wget --inet4-only -d -O - --timeout=2 \
+		--http-user "$USER" --http-password "$PASS" \
+		"http://localhost:$HTTP_PORT/status"
+	then
+		running=true
+		break
+	fi
+done
+
+if [ "$running" != true ]
+then
+	echo "Error: bazel-remote took too long to start"
+	kill -9 $server_pid
+	exit 1
+fi
+
+# Authenticated read should succeed.
+wget --inet4-only -d -O - --timeout=2 \
+	--http-user "$USER" --http-password "$PASS" \
+	"http://localhost:$HTTP_PORT/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# Unauthenticated read should fail.
+if wget --inet4-only -d -O - --timeout=2 \
+	"http://localhost:$HTTP_PORT/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+then
+	echo "Error: expected unauthenticated read to fail"
+	kill -9 $server_pid
+	exit 1
+fi
+
+# Run without auth, expect no access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092
+
+# Run with auth, expect full access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-basic-auth-user "$USER" -basic-auth-pass "$PASS"
+
+# Clean up...
+
+kill -9 $server_pid
+rm -rf "$tmpdir"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -55,6 +55,12 @@ tasks:
     shell_commands:
       - "echo +++ Run TLS tests"
       - ".bazelci/tls-tests.sh"
+  basic_auth_tests:
+    platform: ubuntu2004
+    name: "basic auth tests"
+    shell_commands:
+      - "echo +++ Run basic auth tests"
+      - ".bazelci/basic-auth-tests.sh"
   migration_tests:
     platform: ubuntu2004
     name: "migration tests"

--- a/.bazelci/tls-tests.sh
+++ b/.bazelci/tls-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#set -x
+set -v
 set -e
 set -u
 set -o pipefail
@@ -11,7 +11,10 @@ cd "$SRC_ROOT"
 
 HTTP_PORT=8089
 
-tmpdir=$(mktemp -d bazel-remote-mtls-tests.XXXXXXX --tmpdir=${TMPDIR:-/tmp})
+#export GRPC_GO_LOG_VERBOSITY_LEVEL=99
+#export GRPC_GO_LOG_SEVERITY_LEVEL=info
+
+tmpdir=$(mktemp -d bazel-remote-tls-tests.XXXXXXX --tmpdir=${TMPDIR:-/tmp})
 
 generate_keys() {
 	# Copied from https://github.com/bazelbuild/bazel/blob/master/src/test/testdata/test_tls_certificate/README.md
@@ -32,8 +35,20 @@ generate_keys() {
 	openssl req -passin pass:1111 -new -key "$tmpdir/server.key" \
 		-out "$tmpdir/server.csr" -subj "/CN=${SERVER_CN}"
 
+	# Add subjectAltName aka "SAN", which replaces CN.
+	# Required for Go >= 1.15.
+	cat << EOF > domain.ext
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+EOF
+
 	# Self-signed server certificate:
 	openssl x509 -req -passin pass:1111 -days 358000 -in "$tmpdir/server.csr" \
+		-extfile domain.ext \
 		-CA "$tmpdir/ca.crt" -CAkey "$tmpdir/ca.key" -set_serial 01 -out "$tmpdir/server.crt"
 
 	# Remove passphrase from server key:
@@ -64,17 +79,18 @@ generate_keys
 
 [ -e bazel-remote ] || ./linux-build.sh
 
-echo "Starting bazel-remote..."
+echo "Starting bazel-remote, allowing unauthenticated reads..."
 ./bazel-remote --dir "$tmpdir/cache" --max_size 1 --port "$HTTP_PORT" \
 	--tls_cert_file "$tmpdir/server.crt" \
 	--tls_key_file "$tmpdir/server.key" \
-	--tls_ca_file "$tmpdir/ca.crt" > "$tmpdir/bazel-remote.log" 2>&1 &
+	--tls_ca_file "$tmpdir/ca.crt" \
+	--allow_unauthenticated_reads > "$tmpdir/bazel-remote.log" 2>&1 &
 server_pid=$!
 
 # Wait a bit for the server start up...
 
 running=false
-for i in $(seq 1 10)
+for i in $(seq 1 20)
 do
 	sleep 1
 
@@ -96,12 +112,123 @@ then
 	exit 1
 fi
 
+# Authenticated read.
+wget --inet4-only -d -O - --ca-certificate=$tmpdir/server.crt \
+	--certificate=$tmpdir/client.crt \
+	--private-key=$tmpdir/client.pem \
+	https://localhost:$HTTP_PORT/status
+
+# Unauthenticated read.
+wget --inet4-only -d -O - --ca-certificate=$tmpdir/server.crt \
+	https://localhost:$HTTP_PORT/status
+
+# Run without auth, expect readonly access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-ca-cert-file "$tmpdir/ca.crt" \
+	-reads-should-work
+
+# Run with auth, expect read-write access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-ca-cert-file "$tmpdir/ca.crt" \
+	-client-cert-file "$tmpdir/client.crt" \
+	-client-key-file "$tmpdir/client.key"
+
+# Authenticated build, populate the cache.
 bazel clean
 bazel build //:bazel-remote --remote_cache=grpcs://localhost:9092 \
 	--tls_certificate "$tmpdir/ca.crt" \
 	--tls_client_certificate "$tmpdir/client.crt" \
 	--tls_client_key "$tmpdir/client.pem"
 
+# Unauthenticated build, don't attempt to upload (gRPC).
+bazel clean
+bazel build //:bazel-remote --remote_cache=grpcs://localhost:9092 \
+	--tls_certificate "$tmpdir/ca.crt" \
+	--noremote_upload_local_results
+
+# Unauthenticated build, don't attempt to upload (HTTP).
+bazel clean
+bazel build //:bazel-remote --remote_cache=https://localhost:$HTTP_PORT \
+	--tls_certificate "$tmpdir/ca.crt" \
+	--noremote_upload_local_results
+
+# Unauthenticated gRPC client, should fail to write, but the build
+# should succeed.
+bazel clean
+bazel build //:bazel-remote --remote_cache=grpcs://localhost:9092 \
+	--tls_certificate "$tmpdir/ca.crt" \
+	2>&1 | tee "$tmpdir/unauthenticated_write.log"
+
+grep -A 1 "WARNING: Writing to Remote Cache:" "$tmpdir/unauthenticated_write.log" | \
+	tr '\n' '|' > "$tmpdir/unauthenticated_write.log.singleline"
+if ! grep --silent "WARNING: Writing to Remote Cache:|BulkTransferException|" "$tmpdir/unauthenticated_write.log.singleline"
+then
+	# We seem to always have one cache miss with a rebuild.
+	# So we expect a single cache write attempt, and it should fail.
+	echo "Error: expected a warning when writing to the remote cache fails"
+	exit 1
+fi
+
+# Restart the server with authentication enabled but unauthenticated reads disabled.
+kill -9 $server_pid
+./bazel-remote --dir "$tmpdir/cache" --max_size 1 --port "$HTTP_PORT" \
+	--tls_cert_file "$tmpdir/server.crt" \
+	--tls_key_file "$tmpdir/server.key" \
+	--tls_ca_file "$tmpdir/ca.crt" > "$tmpdir/bazel-remote-authenticated.log" 2>&1 &
+server_pid=$!
+
+# Wait a bit for the server start up...
+
+running=false
+for i in $(seq 1 20)
+do
+	sleep 1
+
+	if wget --inet4-only -d -O - --ca-certificate=$tmpdir/server.crt \
+		--certificate=$tmpdir/client.crt \
+		--private-key=$tmpdir/client.pem \
+		--timeout=2 \
+		"https://localhost:$HTTP_PORT/status"
+	then
+		running=true
+		break
+	fi
+done
+
+if [ "$running" != true ]
+then
+	echo "Error: bazel-remote took too long to start"
+	kill -9 $server_pid
+	exit 1
+fi
+
+# Authenticated read should succeed.
+wget --inet4-only -d -O - --ca-certificate=$tmpdir/server.crt \
+	--certificate=$tmpdir/client.crt \
+	--private-key=$tmpdir/client.pem \
+	--timeout=2 \
+	"https://localhost:$HTTP_PORT/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+# Unauthenticated read should fail.
+if wget --inet4-only -d -O - --ca-certificate=$tmpdir/server.crt \
+	--timeout=2 \
+	"https://localhost:$HTTP_PORT/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+then
+	echo "Error: expected unauthenticated read to fail"
+	kill -9 $server_pid
+	exit 1
+fi
+
+# Run without auth, expect no access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092
+
+# Run with auth, expect full access.
+bazel run //utils/grpcreadclient -- -server-addr localhost:9092 \
+	-ca-cert-file "$tmpdir/ca.crt" \
+	-client-cert-file "$tmpdir/client.crt" \
+	-client-key-file "$tmpdir/client.key"
+
+# Clean up...
 
 kill -9 $server_pid
 rm -rf "$tmpdir"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ OPTIONS:
    --tls_key_file value Path to a pem encoded key file.
       [$BAZEL_REMOTE_TLS_KEY_FILE]
 
+   --allow_unauthenticated_reads If authentication is enabled
+      (--htpasswd_file or --tls_ca_file), allow unauthenticated clients read
+      access. (default: false, ie if authentication is required, read-only
+      requests must also be authenticated) [$BAZEL_REMOTE_UNAUTHENTICATED_READS]
+
    --idle_timeout value The maximum period of having received no request
       after which the server will shut itself down. (default: 0s, ie disabled)
       [$BAZEL_REMOTE_IDLE_TIMEOUT]
@@ -298,6 +303,10 @@ host: localhost
 
 # Alternatively, you can use simple authentication:
 #htpasswd_file: path/to/.htpasswd
+
+# If tls_ca_file or htpasswd_file are specified, you can choose
+# whether or not to allow unauthenticated read access:
+#allow_unauthenticated_reads: false
 
 # If specified, bazel-remote should exit after being idle
 # for this long. Time units can be one of: "s", "m", "h".

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@go_googleapis//google/rpc:status_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//encoding/gzip:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -194,6 +194,13 @@ func (s *grpcServer) maybeInline(inline bool, slice *[]byte, digest **pb.Digest,
 func (s *grpcServer) UpdateActionResult(ctx context.Context,
 	req *pb.UpdateActionResultRequest) (*pb.ActionResult, error) {
 
+	if s.checkClientCertForWrites {
+		err := checkGRPCClientCert(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	logPrefix := "GRPC AC PUT"
 	err := s.validateHash(req.ActionDigest.Hash, req.ActionDigest.SizeBytes, logPrefix)
 	if err != nil {

--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -92,7 +92,18 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 		}
 	}
 
-	// Cache miss. See if we can download one of the URIs.
+	// Cache miss.
+
+	if s.checkClientCertForWrites {
+		err := checkGRPCClientCert(ctx)
+		if err != nil {
+			return &asset.FetchBlobResponse{
+				Status: &status.Status{Code: int32(codes.NotFound)},
+			}, nil
+		}
+	}
+
+	// See if we can download one of the URIs.
 
 	for _, uri := range req.GetUris() {
 		ok, actualHash, size := s.fetchItem(uri, sha256Str)

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -339,6 +339,13 @@ var errDecoderPoolFail error = errors.New("failed to get DecoderWrapper from poo
 
 func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 
+	if s.checkClientCertForWrites {
+		err := checkGRPCClientCert(srv.Context())
+		if err != nil {
+			return err
+		}
+	}
+
 	var resp bytestream.WriteResponse
 	pr, pw := io.Pipe()
 

--- a/server/grpc_cas.go
+++ b/server/grpc_cas.go
@@ -52,6 +52,13 @@ func (s *grpcServer) FindMissingBlobs(ctx context.Context,
 func (s *grpcServer) BatchUpdateBlobs(ctx context.Context,
 	in *pb.BatchUpdateBlobsRequest) (*pb.BatchUpdateBlobsResponse, error) {
 
+	if s.checkClientCertForWrites {
+		err := checkGRPCClientCert(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	resp := pb.BatchUpdateBlobsResponse{
 		Responses: make([]*pb.BatchUpdateBlobsResponse_Response,
 			0, len(in.Requests)),

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -89,6 +89,7 @@ func TestMain(m *testing.M) {
 	validateAC := true
 	mangleACKeys := false
 	enableRemoteAssetAPI := true
+	allowUnauthenticatedReads := false
 
 	go func() {
 		err2 := serveGRPC(
@@ -97,6 +98,7 @@ func TestMain(m *testing.M) {
 			validateAC,
 			mangleACKeys,
 			enableRemoteAssetAPI,
+			allowUnauthenticatedReads,
 			diskCache, accessLogger, errorLogger)
 		if err2 != nil {
 			fmt.Println(err2)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -38,7 +38,7 @@ func TestDownloadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
@@ -103,7 +103,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -167,7 +167,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -208,7 +208,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -250,7 +250,8 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	}
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	unauthenticatedReads := false
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -310,7 +311,8 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	}
 	validate := true
 	mangle := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, "")
+	unauthenticatedReads := false
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -333,7 +335,7 @@ func TestStatusPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -477,7 +479,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, "")
+	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -101,6 +101,13 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "Path to a pem encoded key file.",
 			EnvVars: []string{"BAZEL_REMOTE_TLS_KEY_FILE"},
 		},
+		&cli.BoolFlag{
+			Name:        "allow_unauthenticated_reads",
+			Value:       false,
+			Usage:       "If authentication is enabled (--htpasswd_file or --tls_ca_file), allow unauthenticated clients read access.",
+			DefaultText: "false, ie if authentication is required, read-only requests must also be authenticated",
+			EnvVars:     []string{"BAZEL_REMOTE_UNAUTHENTICATED_READS"},
+		},
 		&cli.DurationFlag{
 			Name:        "idle_timeout",
 			Value:       0,

--- a/utils/grpcreadclient/BUILD.bazel
+++ b/utils/grpcreadclient/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["grpcreadclient.go"],
+    importpath = "github.com/buchgr/bazel-remote/utils/grpcreadclient",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//genproto/build/bazel/remote/execution/v2:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
+        "@go_googleapis//google/bytestream:bytestream_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "grpcreadclient",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/utils/grpcreadclient/grpcreadclient.go
+++ b/utils/grpcreadclient/grpcreadclient.go
@@ -1,0 +1,599 @@
+// This is a client which is used by .bazelci/tls-tests.sh and
+// ~/.bazelci/basic-auth-tests.sh to verify read/write access
+// with and without authentication.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	"github.com/google/uuid"
+
+	"google.golang.org/genproto/googleapis/bytestream"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+)
+
+var emptyDigest = pb.Digest{
+	Hash:      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	SizeBytes: 0,
+}
+
+func main() {
+	// Always required:
+	serverAddr := flag.String("server-addr", "",
+		"gRPC server address in the form hostname:port")
+
+	readsShouldWork := flag.Bool("reads-should-work", false,
+		"whether the server should allow read access in this test")
+
+	// Required for mTLS:
+	clientCertFile := flag.String("client-cert-file", "",
+		"TLS client certificate file (for mTLS)")
+	clientKeyFile := flag.String("client-key-file", "",
+		"TLS client key file (for mTLS)")
+
+	// Required when the server uses TLS:
+	caCertFile := flag.String("ca-cert-file", "",
+		"TLS CA certificate file which signed the server's cert")
+
+	basicAuthUser := flag.String("basic-auth-user", "",
+		"Username for basic authentication")
+
+	basicAuthPass := flag.String("basic-auth-pass", "",
+		"Password for basic authentication")
+
+	showHelp := flag.Bool("help", false, "Show help")
+
+	flag.Parse()
+
+	if *showHelp {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	if *serverAddr == "" {
+		fmt.Println("Error: -server-addr must be specified")
+		os.Exit(1)
+	}
+
+	writesShouldWork := false
+
+	basicAuthFlagCount := 0
+	if *basicAuthUser != "" {
+		basicAuthFlagCount++
+	}
+	if *basicAuthPass != "" {
+		basicAuthFlagCount++
+	}
+	if basicAuthFlagCount != 0 {
+		if basicAuthFlagCount != 2 {
+			fmt.Println("Error: if one of -basic-auth-user or -basic-auth-path are specified, then both must be")
+			os.Exit(1)
+		}
+
+		*readsShouldWork = true
+		writesShouldWork = true
+	}
+
+	if *clientCertFile != "" {
+		*readsShouldWork = true
+		writesShouldWork = true
+	}
+
+	if *clientCertFile != "" && basicAuthFlagCount != 0 {
+		fmt.Println("Error: only one of basic authentication and mTLS can be used")
+		os.Exit(1)
+	}
+
+	err := run(*serverAddr, *readsShouldWork, writesShouldWork, *clientCertFile, *clientKeyFile, *caCertFile, *basicAuthUser, *basicAuthPass)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+type basicAuthCreds struct {
+	user string
+	pass string
+}
+
+func (b *basicAuthCreds) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{
+		"authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte(b.user+":"+b.pass)),
+	}, nil
+}
+
+func (b *basicAuthCreds) RequireTransportSecurity() bool {
+	return true
+}
+
+func dial(serverAddr string, caCertFile string, clientCertFile string, clientKeyFile string, basicAuthUser string, basicAuthPass string) (*grpc.ClientConn, error, context.Context, context.CancelFunc) {
+
+	dialOpts := []grpc.DialOption{grpc.WithBlock()}
+
+	if basicAuthUser != "" {
+		authority := fmt.Sprintf("%s:%s@%s", basicAuthUser, basicAuthPass, serverAddr)
+		dialOpts = append(dialOpts, grpc.WithAuthority(authority))
+	}
+
+	if caCertFile == "" {
+		dialOpts = append(dialOpts, grpc.WithInsecure())
+	} else {
+		fmt.Println("reading", caCertFile)
+
+		caCertData, err := ioutil.ReadFile(caCertFile)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read CA cert file %q: %w",
+				caCertFile, err), nil, nil
+		}
+
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCertData) {
+			return nil, fmt.Errorf("Failed to create CA certificate pool"), nil, nil
+		}
+
+		tlsCfg := &tls.Config{RootCAs: pool}
+
+		if clientCertFile != "" {
+			clientCert, err := tls.LoadX509KeyPair(clientCertFile, clientKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to read client cert file %q (key file %q): %w",
+					clientCertFile, clientKeyFile, err), nil, nil
+			}
+
+			tlsCfg.Certificates = []tls.Certificate{clientCert}
+		}
+
+		creds := credentials.NewTLS(tlsCfg)
+
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	}
+
+	fmt.Println("Dialing...", serverAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	conn, err := grpc.DialContext(ctx, serverAddr, dialOpts...)
+	return conn, err, ctx, cancel
+}
+
+func run(serverAddr string, readsShouldWork bool, writesShouldWork bool, clientCertFile string, clientKeyFile string, caCertFile string, basicAuthUser string, basicAuthPass string) error {
+
+	conn, err, ctx, cancel := dial(serverAddr, caCertFile, clientCertFile, clientKeyFile, basicAuthUser, basicAuthPass)
+	if conn != nil {
+		defer conn.Close()
+	}
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		if !readsShouldWork && !writesShouldWork {
+			fmt.Println("Gave up dialing, as expected:", ctx.Err())
+			return nil
+		}
+
+		return fmt.Errorf("Failed to connect to %q: %w", serverAddr, ctx.Err())
+	default:
+	}
+
+	if err != nil || conn == nil {
+		return fmt.Errorf("Failed to connect %q: %w", serverAddr, err)
+	}
+
+	fmt.Println("Connected.")
+
+	err = checkGetCapabilities(conn, readsShouldWork)
+	if err != nil {
+		return err
+	}
+
+	err = checkCacheReadOps(conn, readsShouldWork)
+	if err != nil {
+		return err
+	}
+
+	err = checkCacheWriteOps(conn, writesShouldWork)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkGetCapabilities(conn *grpc.ClientConn, shouldWork bool) error {
+	capClient := pb.NewCapabilitiesClient(conn)
+
+	_, err := capClient.GetCapabilities(context.Background(),
+		&pb.GetCapabilitiesRequest{})
+
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("GetCapabilities failed, as expected")
+			return nil
+		}
+		return fmt.Errorf("Got capabilities when we expected it to fail")
+	}
+
+	if err != nil {
+		return fmt.Errorf("Failed to get capabilities: %w", err)
+	}
+
+	fmt.Println("GetCapabilities succeeded, as expected")
+	return nil
+}
+
+func checkCacheReadOps(conn *grpc.ClientConn, shouldWork bool) error {
+
+	casClient := pb.NewContentAddressableStorageClient(conn)
+
+	var err error
+
+	err = checkBatchReadBlobs(casClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	err = checkFindMissingBlobs(casClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	acClient := pb.NewActionCacheClient(conn)
+
+	err = checkGetActionResult(acClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	bsClient := bytestream.NewByteStreamClient(conn)
+
+	err = checkBytestreamRead(bsClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkBatchReadBlobs(casClient pb.ContentAddressableStorageClient, shouldWork bool) error {
+	bg := context.Background()
+	brResp, err := casClient.BatchReadBlobs(bg, &pb.BatchReadBlobsRequest{
+		Digests: []*pb.Digest{&emptyDigest},
+	})
+
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("BatchReadBlobs failed, as expected")
+			return nil
+		}
+		return fmt.Errorf("BatchReadBlobs succeeded but was expected to fail")
+	}
+
+	if err != nil {
+		return fmt.Errorf("BatchReadBlobs failed: %w", err)
+	}
+
+	if len(brResp.Responses) != 1 {
+		return fmt.Errorf("Error: expected 1 digest in the response, found: %d",
+			len(brResp.Responses))
+	}
+
+	if brResp.Responses[0] == nil {
+		return fmt.Errorf("Error: found nil reponse")
+	}
+
+	if brResp.Responses[0].Status.Code != int32(codes.OK) {
+		return fmt.Errorf("Error: unexpected reponse: %s",
+			brResp.Responses[0].Status.GetMessage())
+	}
+
+	if brResp.Responses[0].Digest == nil {
+		return fmt.Errorf("Error: found nil digest")
+	}
+
+	if brResp.Responses[0].Digest.Hash != emptyDigest.Hash || brResp.Responses[0].Digest.SizeBytes != 0 {
+		return fmt.Errorf("Error: found different digest")
+	}
+
+	if len(brResp.Responses[0].Data) != 0 {
+		return fmt.Errorf("Error: found non-empty Data")
+	}
+
+	fmt.Println("BatchReadBlobs succeeded, as expected")
+	return nil
+}
+
+func checkFindMissingBlobs(casClient pb.ContentAddressableStorageClient, shouldWork bool) error {
+	req := pb.FindMissingBlobsRequest{
+		BlobDigests: []*pb.Digest{&emptyDigest},
+	}
+
+	resp, err := casClient.FindMissingBlobs(context.Background(), &req)
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("FindMissingBlobsRequest failed, as expected")
+			return nil
+		}
+
+		return fmt.Errorf("Expected FindMissingBlobs to fail, but it succeeded")
+	}
+
+	if err != nil {
+		return fmt.Errorf("FindMissingBlobs failed: %w", err)
+	}
+
+	if len(resp.MissingBlobDigests) != 0 {
+		// The empty blob should always be available.
+		return fmt.Errorf("Expected no missing blobs from FindMissingBlobs call")
+	}
+
+	fmt.Println("FindMissingBlobsRequest succeeded, as expected")
+	return nil
+}
+
+func checkGetActionResult(acClient pb.ActionCacheClient, shouldWork bool) error {
+
+	// We don't expect the cache to contain this entry.
+	req := pb.GetActionResultRequest{
+		ActionDigest: &emptyDigest,
+	}
+
+	ar, err := acClient.GetActionResult(context.Background(), &req)
+
+	if !shouldWork {
+		if ar != nil {
+			return fmt.Errorf("Expected GetActionResult to fail, but it returned a non-nil ActionResult")
+		}
+
+		if err == nil {
+			return fmt.Errorf("Expected GetActionResult to fail and return a non-nil error, but the error was nil")
+		}
+
+		if status.Code(err) != codes.Unauthenticated {
+			return fmt.Errorf("Expected GetActionResult to fail and return Unauthenticated, but got: %s", err.Error())
+		}
+
+		fmt.Println("GetActionResult failed, as expected")
+		return nil
+	}
+
+	if err == nil {
+		return fmt.Errorf("Expected a GetActionResult to return NotFound, but it succeeded somehow")
+	}
+
+	if status.Code(err) != codes.NotFound {
+		return fmt.Errorf("Expected a GetActionResult to return NotFound, but got: %s", err.Error())
+	}
+
+	fmt.Println("GetActionResult succeeded, as expected")
+	return nil
+}
+
+func checkBytestreamRead(bsClient bytestream.ByteStreamClient, shouldWork bool) error {
+
+	resource := fmt.Sprintf("emptyRead/blobs/%s/0", emptyDigest.Hash)
+	req := bytestream.ReadRequest{ResourceName: resource}
+
+	bsrc, err := bsClient.Read(context.Background(), &req)
+
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("BytestreamRead failed, as expected")
+			return nil
+		}
+
+		_, err := bsrc.Recv() // We seem to fail here. Not sure why not above.
+		if err != nil {
+			fmt.Println("BytestreamRead failed, as expected")
+			return nil
+		}
+
+		return fmt.Errorf("Expected bytestream Read to fail, but it succeeded")
+	}
+
+	if err != nil {
+		return fmt.Errorf("Expected bytestream Read to succeed, got %w", err)
+	}
+
+	var downloadedBlob []byte
+	for {
+		bsrResp, err := bsrc.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("Expected success, got %w", err)
+		}
+		if bsrResp == nil {
+			return fmt.Errorf("Expected non-nil response")
+		}
+
+		downloadedBlob = append(downloadedBlob, bsrResp.Data...)
+
+		if len(downloadedBlob) > 0 {
+			return fmt.Errorf("Downloaded too much data, expected an empty blob")
+		}
+	}
+
+	fmt.Println("BytestreamRead succeeded, as expected")
+	return nil
+}
+
+func checkCacheWriteOps(conn *grpc.ClientConn, shouldWork bool) error {
+	var err error
+
+	casClient := pb.NewContentAddressableStorageClient(conn)
+
+	err = checkBatchUpdateBlobs(casClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	acClient := pb.NewActionCacheClient(conn)
+
+	err = checkUpdateActionResult(acClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	bsClient := bytestream.NewByteStreamClient(conn)
+
+	err = checkBytestreamWrite(bsClient, shouldWork)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkUpdateActionResult(acClient pb.ActionCacheClient, shouldWork bool) error {
+	// This is the most important request to get right.
+
+	req := pb.UpdateActionResultRequest{
+		ActionDigest: &pb.Digest{
+			Hash:      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			SizeBytes: 5,
+		},
+		ActionResult: &pb.ActionResult{
+			ExitCode: int32(42),
+		},
+	}
+
+	_, err := acClient.UpdateActionResult(context.Background(), &req)
+
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("UpdateActionResult failed, as expected")
+			return nil
+		}
+
+		return fmt.Errorf("Expected UpdateActionResult to fail, but it succeeded")
+	}
+
+	if err != nil {
+		return fmt.Errorf("Expected UpdateActionResult to succeed, got: %w", err)
+	}
+
+	fmt.Println("UpdateActionResult succeeded, as expected")
+	return nil
+}
+
+func checkBatchUpdateBlobs(casClient pb.ContentAddressableStorageClient, shouldWork bool) error {
+
+	ur := pb.BatchUpdateBlobsRequest_Request{
+		Digest: &pb.Digest{
+			Hash:      "1d996e033d612d9af2b44b70061ee0e868bfd14c2dd90b129e1edeb7953e7985",
+			SizeBytes: 10,
+		},
+		Data: []byte("hellothere"),
+	}
+	req := pb.BatchUpdateBlobsRequest{Requests: []*pb.BatchUpdateBlobsRequest_Request{&ur}}
+
+	resp, err := casClient.BatchUpdateBlobs(context.Background(), &req)
+
+	if !shouldWork {
+		if err != nil {
+			fmt.Println("BatchUpdateBlobs failed, as expected")
+			return nil
+		}
+
+		return fmt.Errorf("Expected BatchUpdateBlobs to fail, but it succeeded")
+	}
+
+	if err != nil {
+		return fmt.Errorf("Expected BatchUpdateBlobs to succeed, got %w", err)
+	}
+
+	rs := resp.GetResponses()
+	if len(rs) != 1 {
+		return fmt.Errorf("Expected BatchUpdateBlobs to have 1 reponse, found %d", len(rs))
+	}
+
+	if rs[0].Digest.Hash != ur.Digest.Hash {
+		return fmt.Errorf("Unexpected digest in reponse")
+	}
+
+	if rs[0].Digest.SizeBytes != ur.Digest.SizeBytes {
+		return fmt.Errorf("Unexpected digest in reponse")
+	}
+
+	if rs[0].Status != nil && rs[0].Status.Code != int32(codes.OK) {
+		return fmt.Errorf("Unexpected unsuccessful response")
+	}
+
+	fmt.Println("BatchUpdateBlobs succeeded, as expected")
+	return nil
+}
+
+func checkBytestreamWrite(bsClient bytestream.ByteStreamClient, shouldWork bool) error {
+	bswc, err := bsClient.Write(context.Background())
+	if err != nil {
+		return fmt.Errorf("BytestreamWrite failed to create ByteStreamClient, got: %w", err)
+	}
+
+	blob := []byte("checkBytestreamWrite.testData")
+	hash := sha256.Sum256(blob)
+	blobDigest := pb.Digest{
+		Hash:      hex.EncodeToString(hash[:]),
+		SizeBytes: int64(len(blob)),
+	}
+
+	resource := fmt.Sprintf("uploads/%s/blobs/%s/%d",
+		uuid.New().String(), blobDigest.Hash, blobDigest.SizeBytes)
+
+	req := bytestream.WriteRequest{
+		ResourceName: resource,
+		FinishWrite:  true,
+		Data:         blob,
+	}
+
+	err = bswc.Send(&req)
+	if err != nil {
+		return fmt.Errorf("BytestreamWrite failed to send data: %w", err)
+	}
+
+	resp, err := bswc.CloseAndRecv()
+	if !shouldWork {
+		if err != nil {
+			statusErr, ok := status.FromError(err)
+			if ok {
+				if statusErr.Code() == codes.Unauthenticated {
+					fmt.Println("BytestreamWrite failed, as expected")
+					return nil
+				}
+
+				return fmt.Errorf("BytestreamWrite got unexpected unauthenticated error: %w", err)
+			}
+
+			return fmt.Errorf("BytestreamWrite got unexpected unauthenticated error: %w", err)
+		}
+
+		return fmt.Errorf("BytestreamWrite CloseAndRecv succeeded, but expected it to fail")
+	}
+
+	if err != nil {
+		return fmt.Errorf("BytestreamWrite failed to CloseAndRecv: %w", err)
+	}
+
+	if resp.CommittedSize != int64(len(blob)) {
+		return fmt.Errorf("BytestreamWrite expected to write %d bytes, but committed %d",
+			len(blob), resp.CommittedSize)
+	}
+
+	fmt.Println("BytestreamWrite succeeded, as expected")
+	return nil
+}


### PR DESCRIPTION
If authentication is enabled, this new flag allows readonly access for unauthenticated clients. Technically, some of the
"readonly" API calls do modify the cache (by affecting the LRU index, or by causing blobs to be downloaded from proxy
backends), but they do not add or modify ActionCache blobs so cannot inject new data into the cache.

Implements #381.