### PR TITLE
[ci] fix some bazelci yaml errors

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -7,28 +7,28 @@ tasks:
   ubuntu1604:
     platform: ubuntu1604
     build_targets:
-    - "..."
+      - "..."
     test_targets:
-    - "..."
+      - "..."
   ubuntu1804:
     platform: ubuntu1804
     build_targets:
-    - "..."
+      - "..."
     test_targets:
-    - "..."
+      - "..."
   ubuntu2004:
     platform: ubuntu2004
     build_targets:
-    - "..."
+      - "..."
     test_targets:
-    - "..."
+      - "..."
   macos:
     platform: macos
     build_targets:
-    # Skip the (linux) container image targets, just build the binary.
-    - "//:bazel-remote"
+      # Skip the (linux) container image targets, just build the binary.
+      - "//:bazel-remote"
     test_targets:
-    - "..."
+      - "..."
   # A series of checks, each in a separate job due to
   # https://github.com/bazelbuild/continuous-integration/issues/938
   check_gofmt:


### PR DESCRIPTION
This might be the cause of the nightly "Try Update Last Green Commit" bazelci errors, which ends with the following:
`Cannot update last green commit due to 1 failing step(s): :cop: Validate .bazelci/presubmit.yml`

Strangely, the 'Validate .bazelci/presubmit.yml' item was passing/green.