### PR TITLE
[grpc] fix variable shadowing in FetchBlob

### DIFF
--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -70,15 +70,16 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 
 			if size < 0 {
 				// We don't know the size yet (bad http backend?).
-				r, size, err := s.cache.Get(cache.CAS, sha256Str, -1, 0)
+				r, actualSize, err := s.cache.Get(cache.CAS, sha256Str, -1, 0)
 				if r != nil {
 					defer r.Close()
 				}
-				if err != nil || size < 0 {
+				if err != nil || actualSize < 0 {
 					s.errorLogger.Printf("failed to get CAS %s from proxy backend size: %d err: %v",
-						size, sha256Str, err)
+						actualSize, sha256Str, err)
 					continue
 				}
+				size = actualSize
 			}
 
 			return &asset.FetchBlobResponse{


### PR DESCRIPTION
In case cache.Contains doesn't return the correct size, i.e. -1, the
correct size needs to be set by getting the value and using the size
from the Get call.

Before this commit the size variable was not correctly updated because
the inner variable shadowed the outer one, this is now fixed.

Fixes #420