### PR TITLE
[s3] remove key_version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,6 @@ OPTIONS:
    --s3.region value The AWS region. Required when not specifying S3/minio
       access keys. [$BAZEL_REMOTE_S3_REGION]
 
-   --s3.key_version value Set to 1 for the legacy flat key format, or 2 for
-      the newer format that reduces the impact of S3 rate limits. (default: 1)
-      [$BAZEL_REMOTE_S3_KEY_VERSION]
-
    --disable_http_ac_validation Whether to disable ActionResult validation
       for HTTP requests. (default: false, ie enable validation)
       [$BAZEL_REMOTE_DISABLE_HTTP_AC_VALIDATION]
@@ -339,7 +335,6 @@ host: localhost
 #  access_key_id: EXAMPLE_ACCESS_KEY
 #  secret_access_key: EXAMPLE_SECRET_KEY
 #  disable_ssl: true
-#  key_version: 2
 #
 # Provide either access_key_id/secret_access_key, or iam_role_endpoint/region.
 # iam_role_endpoint can also be left empty, and figured out automatically.

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -28,7 +28,6 @@ type s3Cache struct {
 	mcore        *minio.Core
 	prefix       string
 	bucket       string
-	keyVersion   int
 	uploadQueue  chan<- uploadReq
 	accessLogger cache.Logger
 	errorLogger  cache.Logger
@@ -102,7 +101,6 @@ func New(s3Config *config.S3CloudStorageConfig, storageMode string, accessLogger
 		mcore:        minioCore,
 		prefix:       s3Config.Prefix,
 		bucket:       s3Config.Bucket,
-		keyVersion:   s3Config.KeyVersion,
 		accessLogger: accessLogger,
 		errorLogger:  errorLogger,
 		v2mode:       storageMode == "zstd",

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ type S3CloudStorageConfig struct {
 	DisableSSL      bool   `yaml:"disable_ssl"`
 	IAMRoleEndpoint string `yaml:"iam_role_endpoint"`
 	Region          string `yaml:"region"`
-	KeyVersion      int    `yaml:"key_version"`
 }
 
 // GoogleCloudStorageConfig stores the configuration of a GCS proxy backend.
@@ -240,10 +239,6 @@ func validateConfig(c *Config) error {
 	if c.S3CloudStorage != nil {
 		if c.S3CloudStorage.AccessKeyID != "" && c.S3CloudStorage.IAMRoleEndpoint != "" {
 			return errors.New("Expected either 's3.access_key_id' or 's3.iam_role_endpoint', found both")
-		}
-
-		if c.S3CloudStorage.KeyVersion < 1 || c.S3CloudStorage.KeyVersion > 2 {
-			return fmt.Errorf("s3.key_version must be either 1 or 2, found %d", c.S3CloudStorage.KeyVersion)
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -173,7 +173,6 @@ s3_proxy:
   prefix: test-prefix
   access_key_id: EXAMPLE_ACCESS_KEY
   secret_access_key: EXAMPLE_SECRET_KEY
-  key_version: 2
 `
 	config, err := newFromYaml([]byte(yaml))
 	if err != nil {
@@ -192,7 +191,6 @@ s3_proxy:
 			Prefix:          "test-prefix",
 			AccessKeyID:     "EXAMPLE_ACCESS_KEY",
 			SecretAccessKey: "EXAMPLE_SECRET_KEY",
-			KeyVersion:      2,
 		},
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,

--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ func main() {
 					DisableSSL:      ctx.Bool("s3.disable_ssl"),
 					IAMRoleEndpoint: ctx.String("s3.iam_role_endpoint"),
 					Region:          ctx.String("s3.region"),
-					KeyVersion:      ctx.Int("s3.key_version"),
 				}
 			}
 

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -199,7 +199,7 @@ func GetCliFlags() []cli.Flag {
 		},
 		&cli.IntFlag{
 			Name:        "s3.key_version",
-			Usage:       "Set to 1 for the legacy flat key format, or 2 for the newer format that reduces the impact of S3 rate limits.",
+			Usage:       "DEPRECATED. Starting from version 2 of bazel-remote enabling compression will automatically enable key version 2. The flag will be removed.",
 			Value:       1,
 			DefaultText: "1",
 			EnvVars:     []string{"BAZEL_REMOTE_S3_KEY_VERSION"},


### PR DESCRIPTION
With the recent introduction of the compression mode, the flag was no
longer used. This seems to have been a breaking change from version 1 to
2. There is no longer the possibility to have key version 2 for
uncompressed mode in S3.