### PR TITLE
cache: Resolve symlinks in disk cache storage path

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -111,8 +111,13 @@ func New(dir string, maxSizeBytes int64, storageMode string, proxy cache.Proxy) 
 		compressionType = casblob.Identity
 	}
 
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Cache{
-		dir:         filepath.Clean(dir),
+		dir:         resolved,
 		storageMode: compressionType,
 		proxy:       proxy,
 	}
@@ -140,7 +145,7 @@ func New(dir string, maxSizeBytes int64, storageMode string, proxy cache.Proxy) 
 
 	c.lru = NewSizedLRU(maxSizeBytes, onEvict)
 
-	err := c.migrateDirectories()
+	err = c.migrateDirectories()
 	if err != nil {
 		return nil, fmt.Errorf("Attempting to migrate the old directory structure failed: %w", err)
 	}


### PR DESCRIPTION
When starting `bazel-remote` with a `dir` pointed to a symbolic link, the LRU filename index crashes with the following error:

```
2021/05/10 01:52:02 bazel-remote built with go1.16.2 from git commit 11ccb655eae3db83f6e1cfe3baa3c632d0da8f65.
2021/05/10 01:52:02 Initial RLIMIT_NOFILE cur: 65536 max: 65536
2021/05/10 01:52:02 Setting RLIMIT_NOFILE cur: 65536 max: 65536
2021/05/10 01:52:02 Loading existing files in /storage/bazel.
2021/05/10 01:52:02 Sorting cache files by atime.
2021/05/10 01:52:02 Building LRU index.
panic: runtime error: slice bounds out of range [15:14]
goroutine 1 [running]:
github.com/buchgr/bazel-remote/cache/disk.(*Cache).loadExistingFiles(0xc00041e000, 0x0, 0x0)
#011cache/disk/disk.go:407 +0xafc
github.com/buchgr/bazel-remote/cache/disk.New(0xc00021a630, 0xe, 0xc80000000, 0xd56dda, 0x4, 0x0, 0x0, 0x462f73, 0xc51de0, 0x0)
#011cache/disk/disk.go:147 +0x6cc
main.run(0xc0000bfd80, 0x0, 0x50)
#011main.go:93 +0x4c5
github.com/urfave/cli/v2.(*App).RunContext(0xc000083500, 0xe637a8, 0xc0000a8000, 0xc0000a2150, 0x3, 0x3, 0x0, 0x0)
#011external/com_github_urfave_cli_v2/app.go:315 +0x6fe
github.com/urfave/cli/v2.(*App).Run(...)
#011external/com_github_urfave_cli_v2/app.go:215
main.main()
#011main.go:62 +0x216
```

This change proposes passing the directory to [`filepath.EvalSymlinks`](https://golang.org/pkg/path/filepath/#EvalSymlinks) before creating the disk cache.

```
EvalSymlinks returns the path name after the evaluation of any symbolic links. If path is relative the result will be relative to the current directory, unless one of the components is an absolute symbolic link. EvalSymlinks calls Clean on the result. 
```

The call to `filepath.Clean` is removed because `EvalSymlinks` does this internally.