### PR TITLE
config: Flag to disable access logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ OPTIONS:
       asset API implementation. (default: false, ie disable remote asset API)
       [$BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API]
 
-   --disable_access_log Whether to disable the standard output access logger.
-      (default: false, ie enable access logging)
-      [$BAZEL_REMOTE_DISABLE_ACCESS_LOG]
+   --access_log_level The access logger verbosity level. If supplied, must
+      be one of "none" or "all". (default: all, ie enable full access logging)
+      [$BAZEL_REMOTE_ACCESS_LOG_LEVEL]
 
    --help, -h  show help (default: false)
 ```
@@ -366,8 +366,8 @@ host: localhost
 # If true, enable experimental remote asset API support:
 #experimental_remote_asset_api: true
 
-# If true, does not print access logs to standard output:
-#disable_access_log: true
+# If supplied, controls the verbosity of the access logger ("none" or "all"):
+#access_log_level: none
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ OPTIONS:
       asset API implementation. (default: false, ie disable remote asset API)
       [$BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API]
 
+   --disable_access_log Whether to disable the standard output access logger.
+      (default: false, ie enable access logging)
+      [$BAZEL_REMOTE_DISABLE_ACCESS_LOG]
+
    --help, -h  show help (default: false)
 ```
 
@@ -361,6 +365,9 @@ host: localhost
 
 # If true, enable experimental remote asset API support:
 #experimental_remote_asset_api: true
+
+# If true, does not print access logs to standard output:
+#disable_access_log: true
 ```
 
 ## Docker

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "logger.go",
         "proxy.go",
         "tls.go",
     ],

--- a/config/config.go
+++ b/config/config.go
@@ -168,6 +168,7 @@ func newFromYaml(data []byte) (*Config, error) {
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: defaultDurationBuckets,
+		AccessLogLevel:         "all",
 	}
 
 	err := yaml.Unmarshal(data, &c)

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,8 @@ type Config struct {
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
 	TLSConfig    *tls.Config
+	AccessLogger *log.Logger
+	ErrorLogger  *log.Logger
 }
 
 var defaultDurationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
@@ -277,7 +279,7 @@ func validateConfig(c *Config) error {
 	return nil
 }
 
-func Get(ctx *cli.Context, accessLogger *log.Logger, errorLogger *log.Logger) (*Config, error) {
+func Get(ctx *cli.Context) (*Config, error) {
 	// Get a Config with all the basic fields set.
 	cfg, err := get(ctx)
 	if err != nil {
@@ -286,7 +288,12 @@ func Get(ctx *cli.Context, accessLogger *log.Logger, errorLogger *log.Logger) (*
 
 	// Set the non-basic fields...
 
-	err = cfg.setProxy(accessLogger, errorLogger)
+	err = cfg.setLogger()
+	if err != nil {
+		return nil, err
+	}
+
+	err = cfg.setProxy()
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
+	DisableAccessLog            bool                      `yaml:"disable_access_log"`
 
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
@@ -102,7 +103,8 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	enableEndpointMetrics bool,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
-	httpWriteTimeout time.Duration) (*Config, error) {
+	httpWriteTimeout time.Duration,
+	disableAccessLog bool) (*Config, error) {
 
 	c := Config{
 		Host:                        host,
@@ -132,6 +134,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,
+		DisableAccessLog:            disableAccessLog,
 	}
 
 	err := validateConfig(&c)
@@ -370,5 +373,6 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Bool("experimental_remote_asset_api"),
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),
+		ctx.Bool("disable_access_log"),
 	)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
-	DisableAccessLog            bool                      `yaml:"disable_access_log"`
+	AccessLogLevel              string                    `yaml:"access_log_level"`
 
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
@@ -104,7 +104,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
-	disableAccessLog bool) (*Config, error) {
+	accessLogLevel string) (*Config, error) {
 
 	c := Config{
 		Host:                        host,
@@ -134,7 +134,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,
-		DisableAccessLog:            disableAccessLog,
+		AccessLogLevel:              accessLogLevel,
 	}
 
 	err := validateConfig(&c)
@@ -279,6 +279,12 @@ func validateConfig(c *Config) error {
 		}
 	}
 
+	switch c.AccessLogLevel {
+	case "none", "all":
+	default:
+		return errors.New("'access_log_level' must be set to either \"none\" or \"all\"")
+	}
+
 	return nil
 }
 
@@ -373,6 +379,6 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Bool("experimental_remote_asset_api"),
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),
-		ctx.Bool("disable_access_log"),
+		ctx.String("access_log_level"),
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,7 +24,7 @@ enable_endpoint_metrics: true
 experimental_remote_asset_api: true
 http_read_timeout: 5s
 http_write_timeout: 10s
-disable_access_log: true
+access_log_level: none
 `
 
 	config, err := newFromYaml([]byte(yaml))
@@ -51,7 +51,7 @@ disable_access_log: true
 		NumUploaders:                100,
 		MaxQueuedUploads:            1000000,
 		MetricsDurationBuckets:      []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
-		DisableAccessLog:            true,
+		AccessLogLevel:              "none",
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,6 +90,7 @@ gcs_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		AccessLogLevel:         "all",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -125,6 +126,7 @@ http_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		AccessLogLevel:         "all",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -197,6 +199,7 @@ s3_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		AccessLogLevel:         "all",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -227,6 +230,7 @@ profile_port: 7070
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		AccessLogLevel:         "all",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -270,6 +274,7 @@ endpoint_metrics_duration_buckets: [.005, .1, 5]
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MetricsDurationBuckets: []float64{0.005, 0.1, 5},
+		AccessLogLevel:         "all",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ enable_endpoint_metrics: true
 experimental_remote_asset_api: true
 http_read_timeout: 5s
 http_write_timeout: 10s
+disable_access_log: true
 `
 
 	config, err := newFromYaml([]byte(yaml))
@@ -50,6 +51,7 @@ http_write_timeout: 10s
 		NumUploaders:                100,
 		MaxQueuedUploads:            1000000,
 		MetricsDurationBuckets:      []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		DisableAccessLog:            true,
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {

--- a/config/logger.go
+++ b/config/logger.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"log"
+	"os"
+)
+
+const (
+	logFlags = log.Ldate | log.Ltime | log.LUTC
+)
+
+func (c *Config) setLogger() error {
+	log.SetFlags(logFlags)
+
+	c.AccessLogger = log.New(os.Stdout, "", logFlags)
+	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
+
+	return nil
+}

--- a/config/logger.go
+++ b/config/logger.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io"
+	"io/ioutil"
 	"log"
 	"os"
 )
@@ -17,7 +17,7 @@ func (c *Config) setLogger() error {
 	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
 
 	if c.DisableAccessLog {
-		c.AccessLogger.SetOutput(io.Discard)
+		c.AccessLogger.SetOutput(ioutil.Discard)
 	}
 
 	return nil

--- a/config/logger.go
+++ b/config/logger.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"log"
 	"os"
 )
@@ -14,6 +15,10 @@ func (c *Config) setLogger() error {
 
 	c.AccessLogger = log.New(os.Stdout, "", logFlags)
 	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
+
+	if c.DisableAccessLog {
+		c.AccessLogger.SetOutput(io.Discard)
+	}
 
 	return nil
 }

--- a/config/logger.go
+++ b/config/logger.go
@@ -16,7 +16,7 @@ func (c *Config) setLogger() error {
 	c.AccessLogger = log.New(os.Stdout, "", logFlags)
 	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
 
-	if c.DisableAccessLog {
+	if c.AccessLogLevel == "none" {
 		c.AccessLogger.SetOutput(ioutil.Discard)
 	}
 

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"net/http"
 	"net/url"
 
@@ -10,11 +9,11 @@ import (
 	"github.com/buchgr/bazel-remote/cache/s3proxy"
 )
 
-func (c *Config) setProxy(accessLogger *log.Logger, errorLogger *log.Logger) error {
+func (c *Config) setProxy() error {
 	if c.GoogleCloudStorage != nil {
 		proxyCache, err := gcsproxy.New(c.GoogleCloudStorage.Bucket,
 			c.GoogleCloudStorage.UseDefaultCredentials, c.GoogleCloudStorage.JSONCredentialsFile,
-			c.StorageMode, accessLogger, errorLogger, c.NumUploaders, c.MaxQueuedUploads)
+			c.StorageMode, c.AccessLogger, c.ErrorLogger, c.NumUploaders, c.MaxQueuedUploads)
 		if err != nil {
 			return err
 		}
@@ -31,7 +30,7 @@ func (c *Config) setProxy(accessLogger *log.Logger, errorLogger *log.Logger) err
 			return err
 		}
 		proxyCache, err := httpproxy.New(baseURL, c.StorageMode,
-			httpClient, accessLogger, errorLogger, c.NumUploaders, c.MaxQueuedUploads)
+			httpClient, c.AccessLogger, c.ErrorLogger, c.NumUploaders, c.MaxQueuedUploads)
 		if err != nil {
 			return err
 		}
@@ -50,7 +49,7 @@ func (c *Config) setProxy(accessLogger *log.Logger, errorLogger *log.Logger) err
 			c.S3CloudStorage.DisableSSL,
 			c.S3CloudStorage.IAMRoleEndpoint,
 			c.S3CloudStorage.Region,
-			c.StorageMode, accessLogger, errorLogger, c.NumUploaders, c.MaxQueuedUploads)
+			c.StorageMode, c.AccessLogger, c.ErrorLogger, c.NumUploaders, c.MaxQueuedUploads)
 		return nil
 	}
 

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -236,5 +236,11 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "false, ie disable remote asset API",
 			EnvVars:     []string{"BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API"},
 		},
+		&cli.BoolFlag{
+			Name:        "disable_access_log",
+			Usage:       "Whether to disable the standard output access logger",
+			DefaultText: "false, ie enable access logging",
+			EnvVars:     []string{"BAZEL_REMOTE_DISABLE_ACCESS_LOG"},
+		},
 	}
 }

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -236,11 +236,12 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "false, ie disable remote asset API",
 			EnvVars:     []string{"BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API"},
 		},
-		&cli.BoolFlag{
-			Name:        "disable_access_log",
-			Usage:       "Whether to disable the standard output access logger",
-			DefaultText: "false, ie enable access logging",
-			EnvVars:     []string{"BAZEL_REMOTE_DISABLE_ACCESS_LOG"},
+		&cli.StringFlag{
+			Name:        "access_log_level",
+			Usage:       "The access logger verbosity level. If supplied, must be one of \"none\" or \"all\".",
+			Value:       "all",
+			DefaultText: "all, ie enable full access logging",
+			EnvVars:     []string{"BAZEL_REMOTE_ACCESS_LOG_LEVEL"},
 		},
 	}
 }


### PR DESCRIPTION
The access logger can be quite noisy when `bazel-remote` is serving thousands of HTTP requests. This PR proposes the addition of a configuration switch to disable the access logger.

The changes:

* Attach the access and error `*log.Logger` instances to the `Config` struct
* Move all logging instantiation logic to a new file `config/logger.go` [+]
* Add a new configuration param `disable_access_log` available both as a CLI flag and in the YAML configuration to disable the access logger

[+] This approach, I think, makes it easier to make further customizations to the logging behavior in the future. For example, this PR doesn't touch the behavior of the error logger, but I suppose there could be a use case for suppressing those messages as well.

[+] This is also required because the current implementation (on master) creates the loggers before the config is read. This change proposes creating the loggers *after* the config is read because we need to have a parsed config to decide how to create the loggers.

Test:

Help text:

```bash
$ bazelisk run //:bazel-remote -- --help
...
   --disable_access_log  Whether to disable the standard output access logger (default: false, ie enable access logging) [$BAZEL_REMOTE_DISABLE_ACCESS_LOG]
```

Default behavior (no change compared to current master):

```bash
$ bazelisk run //:bazel-remote -- --dir /tmp/bazel --max_size 1 --port 8080
...
2021/05/12 00:18:52  GET 200             ::1 /cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

```bash
$ curl -i localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
HTTP/1.1 200 OK
...
```

Disabled access logger via CLI flag:

```bash
$ bazelisk run //:bazel-remote -- --dir /tmp/bazel --max_size 1 --port 8080 --disable_access_log
```

```bash
$ curl -i localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
HTTP/1.1 200 OK
...
```

Disabled access logger via config file:

```bash
$ cat config.yaml
dir: /tmp/bazel
max_size: 1
port: 8080
disable_access_log: true
$ bazelisk run //:bazel-remote -- --config_file $(pwd)/config.yaml
```

```bash
$ curl -i localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
HTTP/1.1 200 OK
...
```