### PR TITLE
Add --max_blob_size flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ OPTIONS:
       be skipped until the queue has space again. (default: 1000000)
       [$BAZEL_REMOTE_MAX_QUEUED_UPLOADS]
 
+   --max_blob_size value The maximum size of an individual blob upload, in bytes. CAS
+      blob uploads with logical size exceeding this value are rejected (not taking into
+      account storage compression). HTTP uploads are rejected with a 400 response code if
+      the logical size of the body exceeds this value. (default: unlimited)
+      [$BAZEL_REMOTE_MAX_BLOB_SIZE]
+
    --num_uploaders value When using proxy backends, sets the number of
       Goroutines to process parallel uploads to backend. (default: 100)
       [$BAZEL_REMOTE_NUM_UPLOADERS]
@@ -336,6 +342,8 @@ host: localhost
 #num_uploaders: 100
 # The maximum number of proxy uploads to queue, before dropping uploads.
 #max_queued_uploads: 1000000
+# The largest blob size that will be accepted, for example 10MB:
+#max_blob_size: 10485760
 #
 #gcs_proxy:
 #  bucket: gcs-bucket

--- a/config/config.go
+++ b/config/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
 	AccessLogLevel              string                    `yaml:"access_log_level"`
-	MaxBlobSize					int	                      `yaml:"max_blob_size"`
+	MaxBlobSize                 int64                     `yaml:"max_blob_size"`
 
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
@@ -106,7 +106,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
 	accessLogLevel string,
-	maxBlobSize int) (*Config, error) {
+	maxBlobSize int64) (*Config, error) {
 
 	c := Config{
 		Host:                        host,
@@ -384,6 +384,6 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),
 		ctx.String("access_log_level"),
-		ctx.Int("max_blob_size"),
+		ctx.Int64("max_blob_size"),
 	)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"os"
 	"sort"
 	"time"
@@ -170,6 +171,7 @@ func newFromYaml(data []byte) (*Config, error) {
 		StorageMode:            "zstd",
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: defaultDurationBuckets,
 		AccessLogLevel:         "all",
 	}
@@ -246,7 +248,7 @@ func validateConfig(c *Config) error {
 		return errors.New("AllowUnauthenticatedReads setting is only available when authentication is enabled")
 	}
 
-	if c.MaxBlobSize <=0 {
+	if c.MaxBlobSize <= 0 {
 		return errors.New("The 'max_blob_size' flag/key must be a positive integer")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -246,6 +246,10 @@ func validateConfig(c *Config) error {
 		return errors.New("AllowUnauthenticatedReads setting is only available when authentication is enabled")
 	}
 
+	if c.MaxBlobSize <=0 {
+		return errors.New("The 'max_blob_size' flag/key must be a positive integer")
+	}
+
 	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil && c.S3CloudStorage != nil {
 		return errors.New("One can specify at most one proxying backend")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
 	AccessLogLevel              string                    `yaml:"access_log_level"`
+	MaxBlobSize					int	                      `yaml:"max_blob_size"`
 
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
@@ -104,7 +105,8 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
-	accessLogLevel string) (*Config, error) {
+	accessLogLevel string,
+	maxBlobSize int) (*Config, error) {
 
 	c := Config{
 		Host:                        host,
@@ -135,6 +137,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,
 		AccessLogLevel:              accessLogLevel,
+		MaxBlobSize:                 maxBlobSize,
 	}
 
 	err := validateConfig(&c)
@@ -381,5 +384,6 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),
 		ctx.String("access_log_level"),
+		ctx.Int("max_blob_size"),
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -50,6 +51,7 @@ access_log_level: none
 		HTTPWriteTimeout:            10 * time.Second,
 		NumUploaders:                100,
 		MaxQueuedUploads:            1000000,
+		MaxBlobSize:                 math.MaxInt64,
 		MetricsDurationBuckets:      []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:              "none",
 	}
@@ -89,6 +91,7 @@ gcs_proxy:
 		},
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -125,6 +128,7 @@ http_proxy:
 		},
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -198,6 +202,7 @@ s3_proxy:
 		},
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -229,6 +234,7 @@ profile_port: 7070
 		ProfileHost:            "",
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -273,6 +279,7 @@ endpoint_metrics_duration_buckets: [.005, .1, 5]
 		StorageMode:            "zstd",
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets: []float64{0.005, 0.1, 5},
 		AccessLogLevel:         "all",
 	}
@@ -282,11 +289,12 @@ endpoint_metrics_duration_buckets: [.005, .1, 5]
 	}
 }
 
-func TestMetricsDurationBucketsNoDupliates(t *testing.T) {
+func TestMetricsDurationBucketsNoDuplicates(t *testing.T) {
 	testConfig := &Config{
 		Host:                   "localhost",
 		Port:                   8080,
 		MaxSize:                42,
+		MaxBlobSize:            200,
 		Dir:                    "/opt/cache-dir",
 		StorageMode:            "uncompressed",
 		MetricsDurationBuckets: []float64{1, 2, 3, 3},
@@ -296,7 +304,7 @@ func TestMetricsDurationBucketsNoDupliates(t *testing.T) {
 		t.Fatal("Expected an error because 'endpoint_metrics_duration_buckets' contained a duplicate")
 	}
 	if !strings.Contains(err.Error(), "'endpoint_metrics_duration_buckets'") {
-		t.Fatal("Expected the error message to mention the invalid 'endpoint_metrics_duration_buckets' key")
+		t.Fatalf("Expected the error message to mention the invalid 'endpoint_metrics_duration_buckets' key. Got '%s'", err.Error())
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -206,14 +206,13 @@ func run(ctx *cli.Context) error {
 			log.Println("experimental gRPC remote asset API:", remoteAssetStatus)
 
 			checkClientCertForWrites := c.AllowUnauthenticatedReads && c.TLSCaFile != ""
-			maxBlobSize := c.MaxBlobSize
 
 			err3 := server.ListenAndServeGRPC(addr, opts,
 				validateAC,
 				c.EnableACKeyInstanceMangling,
 				enableRemoteAssetAPI,
 				checkClientCertForWrites,
-				maxBlobSize,
+				c.MaxBlobSize,
 				diskCache, c.AccessLogger, c.ErrorLogger)
 			if err3 != nil {
 				log.Fatal(err3)

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func run(ctx *cli.Context) error {
 
 	validateAC := !c.DisableHTTPACValidation
 	h := server.NewHTTPCache(diskCache, c.AccessLogger, c.ErrorLogger, validateAC,
-		c.EnableACKeyInstanceMangling, c.AllowUnauthenticatedReads, gitCommit)
+		c.EnableACKeyInstanceMangling, c.AllowUnauthenticatedReads, c.MaxBlobSize, gitCommit)
 
 	var htpasswdSecrets auth.SecretProvider
 	authMode := "disabled"
@@ -206,12 +206,14 @@ func run(ctx *cli.Context) error {
 			log.Println("experimental gRPC remote asset API:", remoteAssetStatus)
 
 			checkClientCertForWrites := c.AllowUnauthenticatedReads && c.TLSCaFile != ""
+			maxBlobSize := c.MaxBlobSize
 
 			err3 := server.ListenAndServeGRPC(addr, opts,
 				validateAC,
 				c.EnableACKeyInstanceMangling,
 				enableRemoteAssetAPI,
 				checkClientCertForWrites,
+				maxBlobSize,
 				diskCache, c.AccessLogger, c.ErrorLogger)
 			if err3 != nil {
 				log.Fatal(err3)

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -42,6 +42,7 @@ type grpcServer struct {
 	depsCheck                bool
 	mangleACKeys             bool
 	checkClientCertForWrites bool
+	maxBlobSize              int
 }
 
 // ListenAndServeGRPC creates a new gRPC server and listens on the given
@@ -52,6 +53,7 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	checkClientCertForWrites bool,
+	maxBlobSize int,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
 	listener, err := net.Listen("tcp", addr)
@@ -59,7 +61,7 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 		return err
 	}
 
-	return serveGRPC(listener, opts, validateACDeps, mangleACKeys, enableRemoteAssetAPI, checkClientCertForWrites, c, a, e)
+	return serveGRPC(listener, opts, validateACDeps, mangleACKeys, enableRemoteAssetAPI, checkClientCertForWrites, maxBlobSize, c, a, e)
 }
 
 func serveGRPC(l net.Listener, opts []grpc.ServerOption,
@@ -67,6 +69,7 @@ func serveGRPC(l net.Listener, opts []grpc.ServerOption,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	checkClientCertForWrites bool,
+	maxBlobSize int,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)
@@ -75,6 +78,7 @@ func serveGRPC(l net.Listener, opts []grpc.ServerOption,
 		depsCheck:                validateACDepsCheck,
 		mangleACKeys:             mangleACKeys,
 		checkClientCertForWrites: checkClientCertForWrites,
+		maxBlobSize:              maxBlobSize,
 	}
 	pb.RegisterActionCacheServer(srv, s)
 	pb.RegisterCapabilitiesServer(srv, s)

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -42,7 +42,7 @@ type grpcServer struct {
 	depsCheck                bool
 	mangleACKeys             bool
 	checkClientCertForWrites bool
-	maxBlobSize              int
+	maxBlobSize              int64
 }
 
 // ListenAndServeGRPC creates a new gRPC server and listens on the given
@@ -53,7 +53,7 @@ func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	checkClientCertForWrites bool,
-	maxBlobSize int,
+	maxBlobSize int64,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
 	listener, err := net.Listen("tcp", addr)
@@ -69,7 +69,7 @@ func serveGRPC(l net.Listener, opts []grpc.ServerOption,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	checkClientCertForWrites bool,
-	maxBlobSize int,
+	maxBlobSize int64,
 	c *disk.Cache, a cache.Logger, e cache.Logger) error {
 
 	srv := grpc.NewServer(opts...)

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -72,6 +72,7 @@ func TestMain(m *testing.M) {
 	}
 	defer os.RemoveAll(dir)
 
+	maxBlobSize := int64(10 * 1024 * 1024)
 	// Add some overhead for likely CAS blob storage expansion.
 	cacheSize := int64(10 * maxChunkSize * 2)
 
@@ -99,6 +100,7 @@ func TestMain(m *testing.M) {
 			mangleACKeys,
 			enableRemoteAssetAPI,
 			allowUnauthenticatedReads,
+			maxBlobSize,
 			diskCache, accessLogger, errorLogger)
 		if err2 != nil {
 			fmt.Println(err2)
@@ -1576,6 +1578,8 @@ func TestParseWriteResource(t *testing.T) {
 	s := &grpcServer{
 		accessLogger: testutils.NewSilentLogger(),
 		errorLogger:  testutils.NewSilentLogger(),
+		// max(int64)
+		maxBlobSize: 9223372036854775807,
 	}
 
 	tcs := []struct {

--- a/server/http.go
+++ b/server/http.go
@@ -296,7 +296,7 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if contentLength > h.maxBlobSize {
-			msg := fmt.Sprintf("write request length %d exceeds configured maximum object size %d MB",
+			msg := fmt.Sprintf("write request length %d exceeds configured maximum object size %d",
 				contentLength, h.maxBlobSize)
 			http.Error(w, msg, http.StatusBadRequest)
 			h.errorLogger.Printf("PUT %s: %s", path(kind, hash), msg)

--- a/server/http.go
+++ b/server/http.go
@@ -45,7 +45,7 @@ type httpCache struct {
 	mangleACKeys             bool
 	gitCommit                string
 	checkClientCertForWrites bool
-	maxBlobSize              int
+	maxBlobSize              int64
 }
 
 type statusPageData struct {
@@ -63,7 +63,7 @@ type statusPageData struct {
 // accessLogger will print one line for each HTTP request to stdout.
 // errorLogger will print unexpected server errors. Inexistent files and malformed URLs will not
 // be reported.
-func NewHTTPCache(cache *disk.Cache, accessLogger cache.Logger, errorLogger cache.Logger, validateAC bool, mangleACKeys bool, checkClientCertForWrites bool, maxBlobSize int, commit string) HTTPCache {
+func NewHTTPCache(cache *disk.Cache, accessLogger cache.Logger, errorLogger cache.Logger, validateAC bool, mangleACKeys bool, checkClientCertForWrites bool, maxBlobSize int64, commit string) HTTPCache {
 
 	_, _, numItems, _ := cache.Stats()
 
@@ -295,7 +295,7 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if (h.maxBlobSize > 0 && contentLength > int64(h.maxBlobSize) * 1024 * 1024) {
+		if contentLength > h.maxBlobSize {
 			msg := fmt.Sprintf("write request length %d exceeds configured maximum object size %d MB",
 				contentLength, h.maxBlobSize)
 			http.Error(w, msg, http.StatusBadRequest)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -28,6 +28,7 @@ func TestDownloadFile(t *testing.T) {
 	defer os.RemoveAll(cacheDir)
 
 	blobSize := int64(1024)
+	maxBlobSize := blobSize
 
 	data, hash := testutils.RandomDataAndHash(blobSize)
 
@@ -38,7 +39,7 @@ func TestDownloadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, maxBlobSize, "")
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
@@ -103,7 +104,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, blobSize, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -167,7 +168,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, 1024, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -208,7 +209,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, 1000, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -251,7 +252,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	validate := true
 	mangle := false
 	unauthenticatedReads := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, 0, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -312,7 +313,7 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	validate := true
 	mangle := false
 	unauthenticatedReads := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, 0, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -335,7 +336,7 @@ func TestStatusPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, 0, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -479,7 +480,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, 0, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -121,6 +121,13 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "When using proxy backends, sets the maximum number of objects in queue for upload. If the queue is full, uploads will be skipped until the queue has space again.",
 			EnvVars: []string{"BAZEL_REMOTE_MAX_QUEUED_UPLOADS"},
 		},
+		&cli.Int64Flag{
+			Name:    "max_blob_size",
+			Value:   0,
+			Usage:   "The maximum size of an individual blob stored in the cache in MiB. Upload requests will fail for any larger blobs.",
+			DefaultText: "0, ie unlimited",
+			EnvVars: []string{"BAZEL_REMOTE_MAX_BLOB_SIZE"},
+		},
 		&cli.IntFlag{
 			Name:    "num_uploaders",
 			Value:   100,

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -125,7 +125,7 @@ func GetCliFlags() []cli.Flag {
 		&cli.Int64Flag{
 			Name:        "max_blob_size",
 			Value:       math.MaxInt64,
-			Usage:       "The maximum size of an individual blob stored in the cache in bytes. Upload requests will fail for any larger blobs.",
+			Usage:       "The maximum size of an individual blob upload, in bytes. CAS blob uploads with logical size exceeding this value are rejected (not taking into account storage compression). HTTP uploads are rejected with a 400 response code if the logical size of the body exceeds this value.",
 			DefaultText: "unlimited",
 			EnvVars:     []string{"BAZEL_REMOTE_MAX_BLOB_SIZE"},
 		},

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"github.com/urfave/cli/v2"
+	"math"
 )
 
 // GetCliFlags returns a slice of cli.Flag's that bazel-remote accepts.
@@ -122,11 +123,11 @@ func GetCliFlags() []cli.Flag {
 			EnvVars: []string{"BAZEL_REMOTE_MAX_QUEUED_UPLOADS"},
 		},
 		&cli.Int64Flag{
-			Name:    "max_blob_size",
-			Value:   0,
-			Usage:   "The maximum size of an individual blob stored in the cache in MiB. Upload requests will fail for any larger blobs.",
-			DefaultText: "0, ie unlimited",
-			EnvVars: []string{"BAZEL_REMOTE_MAX_BLOB_SIZE"},
+			Name:        "max_blob_size",
+			Value:       math.MaxInt64,
+			Usage:       "The maximum size of an individual blob stored in the cache in bytes. Upload requests will fail for any larger blobs.",
+			DefaultText: "unlimited",
+			EnvVars:     []string{"BAZEL_REMOTE_MAX_BLOB_SIZE"},
 		},
 		&cli.IntFlag{
 			Name:    "num_uploaders",


### PR DESCRIPTION
This causes both a gRPC and HTTP endpoint to reject blob writes that are larger than the configured size (in MB)

Fixes #440 