### PR TITLE
[bytestream] be careful not to hang goroutines writing to putResult

### DIFF
--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -349,8 +349,8 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 	var resp bytestream.WriteResponse
 	pr, pw := io.Pipe()
 
-	putResult := make(chan error)
-	recvResult := make(chan error)
+	putResult := make(chan error, 1)
+	recvResult := make(chan error, 1)
 	resourceNameChan := make(chan string, 1)
 
 	cmp := casblob.Identity
@@ -437,7 +437,8 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 				}
 
 				go func() {
-					putResult <- s.cache.Put(cache.CAS, hash, size, rc)
+					err := s.cache.Put(cache.CAS, hash, size, rc)
+					putResult <- err
 				}()
 
 				firstIteration = false


### PR DESCRIPTION
If this goroutine blocks trying to write to `putResult` after `Write` exits then it will leak.

We can avoid this by making `putResult` a buffered channel with length 1, since a `Write` call will send to this channel at most
once. Then that single send will never block, and the goroutine can exit.

While we're at it, let's make `recvResult` buffered too, just in case.

Fixes #444.