### PR TITLE
[bytestream] be careful not to hang goroutines writing to putResult

### DIFF
--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -234,8 +234,8 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 	var resp bytestream.WriteResponse
 	pr, pw := io.Pipe()
 
-	putResult := make(chan error)
-	recvResult := make(chan error)
+	putResult := make(chan error, 1)
+	recvResult := make(chan error, 1)
 	resourceNameChan := make(chan string, 1)
 
 	go func() {
@@ -297,7 +297,8 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 				}
 
 				go func() {
-					putResult <- s.cache.Put(cache.CAS, hash, size, pr)
+					err := s.cache.Put(cache.CAS, hash, size, pr)
+					putResult <- err
 				}()
 
 				firstIteration = false


### PR DESCRIPTION
This is a backport of #445 which fixes #444.