### PR TITLE
install go for CI jobs

### DIFF
--- a/.bazelci/buildkite-install-go.sh
+++ b/.bazelci/buildkite-install-go.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+wget -o $HOME/go1.16.7.linux-amd64.tar.gz https://golang.org/dl/go1.16.7.linux-amd64.tar.gz 1>&2
+tar -xv -C $HOME -f go1.16.7.linux-amd64.tar.gz 1>&2

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -35,23 +35,27 @@ tasks:
     platform: ubuntu2004
     name: "go fmt"
     shell_commands:
+      - ".bazelci/buildkite-install-go.sh"
       - "echo +++ Check go format"
-      - ".bazelci/check-gofmt.sh `find . -name '*.go'`"
+      - "PATH=$HOME/go/bin:$PATH .bazelci/check-gofmt.sh `find . -name '*.go'`"
   check_go_vet:
     platform: ubuntu2004
     name: "go vet"
     shell_commands:
+      - ".bazelci/buildkite-install-go.sh"
       - "echo +++ Check go vet"
-      - "go vet ./..."
+      - "PATH=$HOME/go/bin:$PATH go vet ./..."
   check_go_test_race:
     platform: ubuntu2004
     name: "go test --race"
     shell_commands:
+      - ".bazelci/buildkite-install-go.sh"
       - "echo +++ Running go test with race detector"
-      - "go test -race ./..."
+      - "PATH=$HOME/go/bin:$PATH go test -race ./..."
   end_to_end_test:
     platform: ubuntu2004
     name: "end-to-end test"
     shell_commands:
+      - ".bazelci/buildkite-install-go.sh"
       - "echo +++ Run end-to-end system test"
-      - ".bazelci/system-test.sh"
+      - "PATH=$HOME/go/bin:$PATH .bazelci/system-test.sh"


### PR DESCRIPTION
Go was removed from the default images recently, along with a few other packages:
https://github.com/bazelbuild/continuous-integration/commit/273db8eb636b27dec8fdd9e88e7e9a7b5fae286c