### PR TITLE
[disk] limit the number of concurrent file removals

### DIFF
--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
 	google.golang.org/genproto v0.0.0-20200722002428-88e341933a54
 	google.golang.org/grpc v1.31.0


### PR DESCRIPTION
The disk cache's eviction function removes files in a separate goroutine for each, to avoid holding the lock while waiting for the filesystem.

If the disk/filesystem is too slow to keep up with the rate of file removals, we can hit Go's default 10,000 operating system thread limits, and crash. To avoid this, let's try limiting the number of concurrent file removals to half the default limit (5,000).

This might fix #479.