### PR TITLE
Support Unix domain socket listeners for HTTP and gRPC servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,11 @@ max_size: 100
 # The form to store CAS blobs in ("zstd" or "uncompressed"):
 #storage_mode: zstd
 
-# The server listener address for HTTP/HTTPS. The expected format is
-# [host]:port for TCP or unix:///path/to/socket.sock Unix sockets.
+# The server listener address for HTTP/HTTPS. For TCP listeners,
+# use [host]:port, where host is optional (default 0.0.0.0) and can
+# be either a hostname or IP address. For Unix domain socket listeners,
+# use unix:///path/to/socket.sock, where /path/to/socket.sock can be
+# either an absolute or relative path to a socket path.
 http_address: localhost:8080
 # The server listener address for gRPC:
 #grpc_address: localhost:9092

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ OPTIONS:
       domain sockets. [$BAZEL_REMOTE_HTTP_ADDRESS]
 
    --grpc_port value DEPRECATED. Use --grpc_address to specify the gRPC
-      server listener. (default: 9092) [$BAZEL_REMOTE_GRPC_PORT]
+      server listener. Set to 0 to disable. (default: 9092)
+      [$BAZEL_REMOTE_GRPC_PORT]
 
    --grpc_address value Address specification for the gRPC server listener,
       formatted either as [host]:port for TCP or unix://path.sock for Unix

--- a/README.md
+++ b/README.md
@@ -153,8 +153,14 @@ OPTIONS:
    --port value The port the HTTP server listens on. (default: 8080)
       [$BAZEL_REMOTE_PORT]
 
+   --socket value Unix domain socket path to listen on. Takes precedence over
+      host and port. [$BAZEL_REMOTE_SOCKET]
+
    --grpc_port value The port the gRPC server listens on. Set to 0 to
       disable. (default: 9092) [$BAZEL_REMOTE_GRPC_PORT]
+
+   --grpc_socket value Unix domain socket path the gRPC server listens on.
+      Takes precedence over gRPC port. [$BAZEL_REMOTE_GRPC_SOCKET]
 
    --profile_host value A host address to listen on for profiling, if enabled
       by a valid --profile_port setting. (default: "127.0.0.1")
@@ -313,6 +319,9 @@ host: localhost
 #port: 8080
 # The port to use for gRPC:
 #grpc_port: 9092
+# Optionally use Unix domain sockets for HTTP/HTTPS and/or gRPC:
+#socket: /var/run/bazel-remote/http.sock
+#grpc_socket: /var/run/bazel-remote/grpc.sock
 
 # If profile_port is specified, then serve /debug/pprof/* URLs here:
 #profile_host: 127.0.0.1
@@ -387,7 +396,7 @@ host: localhost
 #  auth_method: iam_role
 #  iam_role_endpoint: http://169.254.169.254
 #  region: us-east-1
-# 
+#
 # AWS credentials file.
 #  auth_method: credentials_file
 #  aws_shared_credentials_file: path/to/aws/credentials

--- a/README.md
+++ b/README.md
@@ -147,20 +147,23 @@ OPTIONS:
    --storage_mode value Which format to store CAS blobs in. Must be one of
       "zstd" or "uncompressed". (default: "zstd") [$BAZEL_REMOTE_STORAGE_MODE]
 
-   --host value Address to listen on. Listens on all network interfaces by
-      default. [$BAZEL_REMOTE_HOST]
+   --host value DEPRECATED. Use --http_address to specify the HTTP server
+      listener. [$BAZEL_REMOTE_HOST]
 
-   --port value The port the HTTP server listens on. (default: 8080)
-      [$BAZEL_REMOTE_PORT]
+   --port value DEPRECATED. Use --http_address to specify the HTTP server
+      listener. (default: 8080) [$BAZEL_REMOTE_PORT]
 
-   --socket value Unix domain socket path to listen on. Takes precedence over
-      host and port. [$BAZEL_REMOTE_SOCKET]
+   --http_address value Address specification for the HTTP server listener,
+      formatted either as [host]:port for TCP or unix://path.sock for Unix
+      domain sockets. [$BAZEL_REMOTE_HTTP_ADDRESS]
 
-   --grpc_port value The port the gRPC server listens on. Set to 0 to
-      disable. (default: 9092) [$BAZEL_REMOTE_GRPC_PORT]
+   --grpc_port value DEPRECATED. Use --grpc_address to specify the gRPC
+      server listener. (default: 9092) [$BAZEL_REMOTE_GRPC_PORT]
 
-   --grpc_socket value Unix domain socket path the gRPC server listens on.
-      Takes precedence over gRPC port. [$BAZEL_REMOTE_GRPC_SOCKET]
+   --grpc_address value Address specification for the gRPC server listener,
+      formatted either as [host]:port for TCP or unix://path.sock for Unix
+      domain sockets. Set to 'none' to disable.
+      [$BAZEL_REMOTE_GRPC_ADDRESS]
 
    --profile_host value A host address to listen on for profiling, if enabled
       by a valid --profile_port setting. (default: "127.0.0.1")
@@ -314,14 +317,11 @@ max_size: 100
 # The form to store CAS blobs in ("zstd" or "uncompressed"):
 #storage_mode: zstd
 
-host: localhost
-# The port to use for HTTP/HTTPS:
-#port: 8080
-# The port to use for gRPC:
-#grpc_port: 9092
-# Optionally use Unix domain sockets for HTTP/HTTPS and/or gRPC:
-#socket: /var/run/bazel-remote/http.sock
-#grpc_socket: /var/run/bazel-remote/grpc.sock
+# The server listener address for HTTP/HTTPS. The expected format is
+# [host]:port for TCP or unix:///path/to/socket.sock Unix sockets.
+http_address: localhost:8080
+# The server listener address for gRPC:
+#grpc_address: localhost:9092
 
 # If profile_port is specified, then serve /debug/pprof/* URLs here:
 #profile_host: 127.0.0.1

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ type Config struct {
 	GRPCPort int    `yaml:"grpc_port"`
 }
 
+const disabledGRPCListener = "none"
+
 var defaultDurationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
 
 // newFromArgs returns a validated Config with the specified values, and
@@ -228,7 +230,7 @@ func validateConfig(c *Config) error {
 		return errors.New("'http_address' must either be formatted as [host]:port or unix://socket.path")
 	}
 
-	if c.GRPCAddress != "" && c.GRPCAddress != "none" {
+	if c.GRPCAddress != "" && c.GRPCAddress != disabledGRPCListener {
 		_, grpcPort, err := net.SplitHostPort(c.GRPCAddress)
 		if err != nil && !strings.HasPrefix(c.GRPCAddress, "unix://") {
 			return errors.New("'grpc_address' must either be formatted as [host]:port or unix://socket.path")
@@ -239,7 +241,7 @@ func validateConfig(c *Config) error {
 		}
 	}
 
-	if c.GRPCAddress == "none" && c.ExperimentalRemoteAssetAPI {
+	if c.GRPCAddress == disabledGRPCListener && c.ExperimentalRemoteAssetAPI {
 		return errors.New("Remote Asset API support depends on gRPC being enabled")
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,9 @@ type HTTPBackendConfig struct {
 type Config struct {
 	Host                        string                    `yaml:"host"`
 	Port                        int                       `yaml:"port"`
+	Socket                      string                    `yaml:"socket"`
 	GRPCPort                    int                       `yaml:"grpc_port"`
+	GRPCSocket                  string                    `yaml:"grpc_socket"`
 	ProfileHost                 string                    `yaml:"profile_host"`
 	ProfilePort                 int                       `yaml:"profile_port"`
 	Dir                         string                    `yaml:"dir"`
@@ -74,7 +76,7 @@ var defaultDurationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
 // newFromArgs returns a validated Config with the specified values, and
 // an error if there were any problems with the validation.
 func newFromArgs(dir string, maxSize int, storageMode string,
-	host string, port int, grpcPort int,
+	host string, port int, socket string, grpcPort int, grpcSocket string,
 	profileHost string, profilePort int,
 	htpasswdFile string,
 	maxQueuedUploads int,
@@ -100,7 +102,9 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	c := Config{
 		Host:                        host,
 		Port:                        port,
+		Socket:                      socket,
 		GRPCPort:                    grpcPort,
+		GRPCSocket:                  grpcSocket,
 		ProfileHost:                 profileHost,
 		ProfilePort:                 profilePort,
 		Dir:                         dir,
@@ -209,8 +213,8 @@ func validateConfig(c *Config) error {
 		return errors.New("At most one of the S3/GCS/HTTP proxy backends is allowed")
 	}
 
-	if c.Port == 0 {
-		return errors.New("A valid 'port' flag/key must be specified")
+	if c.Port == 0 && c.Socket == "" {
+		return errors.New("Either the 'socket' or 'port' flag/key must be specified")
 	}
 
 	if c.GRPCPort < 0 {
@@ -359,7 +363,9 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.String("storage_mode"),
 		ctx.String("host"),
 		ctx.Int("port"),
+		ctx.String("socket"),
 		ctx.Int("grpc_port"),
+		ctx.String("grpc_socket"),
 		ctx.String("profile_host"),
 		ctx.Int("profile_port"),
 		ctx.String("htpasswd_file"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -452,3 +452,19 @@ storage_mode: zstd
 		t.Fatalf("Expected '%+v' but got '%+v'", expectedConfig, config)
 	}
 }
+
+func TestSocketPathMissing(t *testing.T) {
+	testConfig := &Config{
+		HTTPAddress: "unix://",
+		Dir:         "/opt/cache-dir",
+		MaxSize:     100,
+		StorageMode: "zstd",
+	}
+	err := validateConfig(testConfig)
+	if err == nil {
+		t.Fatal("Expected an error because 'http_address' specifies an invalid Unix socket")
+	}
+	if !strings.Contains(err.Error(), "'http_address'") {
+		t.Fatal("Expected the error message to mention the missing 'http_address' key/flag")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -369,3 +369,33 @@ storage_mode: gzip
 		}
 	}
 }
+
+func TestValidSocketOverride(t *testing.T) {
+	yaml := `socket: /tmp/http.sock
+grpc_socket: /tmp/grpc.sock
+dir: /opt/cache-dir
+max_size: 42
+storage_mode: zstd
+`
+	config, err := newFromYaml([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedConfig := &Config{
+		Socket:                 "/tmp/http.sock",
+		GRPCSocket:             "/tmp/grpc.sock",
+		Dir:                    "/opt/cache-dir",
+		MaxSize:                42,
+		StorageMode:            "zstd",
+		NumUploaders:           100,
+		MaxQueuedUploads:       1000000,
+		MaxBlobSize:            math.MaxInt64,
+		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
+		AccessLogLevel:         "all",
+	}
+
+	if !cmp.Equal(config, expectedConfig) {
+		t.Fatalf("Expected '%+v' but got '%+v'", expectedConfig, config)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	auth "github.com/abbot/go-http-auth"
+
 	"github.com/buchgr/bazel-remote/cache"
 	"github.com/buchgr/bazel-remote/cache/disk"
 
@@ -121,9 +123,9 @@ func run(ctx *cli.Context) error {
 		authMode = "basic"
 		htpasswdSecrets = auth.HtpasswdFileProvider(c.HtpasswdFile)
 		if c.AllowUnauthenticatedReads {
-			cacheHandler = unauthenticatedReadWrapper(cacheHandler, htpasswdSecrets, c.Host)
+			cacheHandler = unauthenticatedReadWrapper(cacheHandler, htpasswdSecrets, c.HTTPAddress)
 		} else {
-			cacheHandler = authWrapper(cacheHandler, htpasswdSecrets, c.Host)
+			cacheHandler = authWrapper(cacheHandler, htpasswdSecrets, c.HTTPAddress)
 		}
 	} else if c.TLSCaFile != "" {
 		authMode = "mTLS"
@@ -166,17 +168,8 @@ func run(ctx *cli.Context) error {
 		mux.HandleFunc("/", cacheHandler)
 	}
 
-	if c.GRPCPort > 0 || c.GRPCSocket != "" {
-		if c.GRPCPort == c.Port {
-			log.Fatalf("Error: gRPC and HTTP ports (%d) conflict", c.Port)
-		}
-
+	if c.GRPCAddress != "none" {
 		go func() {
-			addr := net.JoinHostPort(c.Host, strconv.Itoa(c.GRPCPort))
-			if c.GRPCSocket != "" {
-				addr = c.GRPCSocket
-			}
-
 			opts := []grpc.ServerOption{}
 			streamInterceptors := []grpc.StreamServerInterceptor{}
 			unaryInterceptors := []grpc.UnaryServerInterceptor{}
@@ -206,8 +199,6 @@ func run(ctx *cli.Context) error {
 			opts = append(opts, grpc.ChainStreamInterceptor(streamInterceptors...))
 			opts = append(opts, grpc.ChainUnaryInterceptor(unaryInterceptors...))
 
-			log.Printf("Starting gRPC server on address %s", addr)
-
 			validateAC := !c.DisableGRPCACDepsCheck
 			validateStatus := "disabled"
 			if validateAC {
@@ -225,9 +216,13 @@ func run(ctx *cli.Context) error {
 			checkClientCertForWrites := c.AllowUnauthenticatedReads && c.TLSCaFile != ""
 
 			network := "tcp"
-			if c.GRPCSocket != "" {
+			addr := c.GRPCAddress
+			if strings.HasPrefix(c.GRPCAddress, "unix://") {
 				network = "unix"
+				addr = c.GRPCAddress[len("unix://"):]
 			}
+
+			log.Printf("Starting gRPC server on address %s", addr)
 
 			err3 := server.ListenAndServeGRPC(
 				network, addr, opts,
@@ -259,10 +254,10 @@ func run(ctx *cli.Context) error {
 	}
 
 	var ln net.Listener
-	if c.Socket != "" {
-		ln, err = net.Listen("unix", c.Socket)
+	if strings.HasPrefix(c.HTTPAddress, "unix://") {
+		ln, err = net.Listen("unix", c.HTTPAddress[len("unix://"):])
 	} else {
-		ln, err = net.Listen("tcp", net.JoinHostPort(c.Host, strconv.Itoa(c.Port)))
+		ln, err = net.Listen("tcp", c.HTTPAddress)
 	}
 	if err != nil {
 		log.Fatal(err)
@@ -279,7 +274,7 @@ func run(ctx *cli.Context) error {
 		idleTimer.Start()
 	}
 
-	log.Printf("Starting HTTP server on address %s", httpServer.Addr)
+	log.Printf("Starting HTTP server on address %s", c.HTTPAddress)
 	log.Println("HTTP AC validation:", validateStatus)
 	return httpServer.Serve(ln)
 }
@@ -306,16 +301,16 @@ func wrapIdleHandler(handler http.HandlerFunc, idleTimer *idle.Timer, accessLogg
 
 // A http.HandlerFunc wrapper which requires successful basic
 // authentication for all requests.
-func authWrapper(handler http.HandlerFunc, secrets auth.SecretProvider, host string) http.HandlerFunc {
-	authenticator := &auth.BasicAuth{Realm: host, Secrets: secrets}
+func authWrapper(handler http.HandlerFunc, secrets auth.SecretProvider, addr string) http.HandlerFunc {
+	authenticator := &auth.BasicAuth{Realm: addr, Secrets: secrets}
 	return auth.JustCheck(authenticator, handler)
 }
 
 // A http.HandlerFunc wrapper which requires successful basic
 // authentication for write requests, but allows unauthenticated
 // read requests.
-func unauthenticatedReadWrapper(handler http.HandlerFunc, secrets auth.SecretProvider, host string) http.HandlerFunc {
-	authenticator := &auth.BasicAuth{Realm: host, Secrets: secrets}
+func unauthenticatedReadWrapper(handler http.HandlerFunc, secrets auth.SecretProvider, addr string) http.HandlerFunc {
+	authenticator := &auth.BasicAuth{Realm: addr, Secrets: secrets}
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet || r.Method == http.MethodHead {

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -48,14 +48,15 @@ type grpcServer struct {
 // ListenAndServeGRPC creates a new gRPC server and listens on the given
 // address. This function either returns an error quickly, or triggers a
 // blocking call to https://godoc.org/google.golang.org/grpc#Server.Serve
-func ListenAndServeGRPC(addr string, opts []grpc.ServerOption,
+func ListenAndServeGRPC(
+	network string, addr string, opts []grpc.ServerOption,
 	validateACDeps bool,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	checkClientCertForWrites bool,
 	c disk.Cache, a cache.Logger, e cache.Logger) error {
 
-	listener, err := net.Listen("tcp", addr)
+	listener, err := net.Listen(network, addr)
 	if err != nil {
 		return err
 	}

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -45,32 +45,31 @@ func GetCliFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "host",
 			Value:   "",
-			Usage:   "Address to listen on. Listens on all network interfaces by default.",
+			Usage:   "DEPRECATED. Use --http_address to specify the HTTP server listener.",
 			EnvVars: []string{"BAZEL_REMOTE_HOST"},
 		},
 		&cli.IntFlag{
 			Name:    "port",
 			Value:   8080,
-			Usage:   "The port the HTTP server listens on.",
+			Usage:   "DEPRECATED. Use --http_address to specify the HTTP server listener.",
 			EnvVars: []string{"BAZEL_REMOTE_PORT"},
 		},
 		&cli.StringFlag{
-			Name:    "socket",
-			Value:   "",
-			Usage:   "Unix domain socket path to listen on. Takes precedence over host and port.",
-			EnvVars: []string{"BAZEL_REMOTE_SOCKET"},
+			Name:    "http_address",
+			Usage:   "Address specification for the HTTP server listener, formatted either as [host]:port for TCP or unix://path.sock for Unix domain sockets.",
+			EnvVars: []string{"BAZEL_REMOTE_HTTP_ADDRESS"},
 		},
 		&cli.IntFlag{
 			Name:    "grpc_port",
 			Value:   9092,
-			Usage:   "The port the gRPC server listens on. Set to 0 to disable.",
+			Usage:   "DEPRECATED. Use --grpc_address to specify the gRPC server listener.",
 			EnvVars: []string{"BAZEL_REMOTE_GRPC_PORT"},
 		},
 		&cli.StringFlag{
-			Name:    "grpc_socket",
-			Value:   "",
-			Usage:   "Unix domain socket path the gRPC server listens on. Takes precedence over gRPC port.",
-			EnvVars: []string{"BAZEL_REMOTE_GRPC_SOCKET"},
+			Name: "grpc_address",
+			Usage: "Address specification for the gRPC server listener, formatted either as [host]:port for TCP or unix://path.sock for Unix domain sockets. " +
+				"Set to 'none' to disable.",
+			EnvVars: []string{"BAZEL_REMOTE_GRPC_ADDRESS"},
 		},
 		&cli.StringFlag{
 			Name:    "profile_host",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -62,7 +62,7 @@ func GetCliFlags() []cli.Flag {
 		&cli.IntFlag{
 			Name:    "grpc_port",
 			Value:   9092,
-			Usage:   "DEPRECATED. Use --grpc_address to specify the gRPC server listener.",
+			Usage:   "DEPRECATED. Use --grpc_address to specify the gRPC server listener. Set to 0 to disable.",
 			EnvVars: []string{"BAZEL_REMOTE_GRPC_PORT"},
 		},
 		&cli.StringFlag{

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -54,11 +54,23 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "The port the HTTP server listens on.",
 			EnvVars: []string{"BAZEL_REMOTE_PORT"},
 		},
+		&cli.StringFlag{
+			Name:    "socket",
+			Value:   "",
+			Usage:   "Unix domain socket path to listen on. Takes precedence over host and port.",
+			EnvVars: []string{"BAZEL_REMOTE_SOCKET"},
+		},
 		&cli.IntFlag{
 			Name:    "grpc_port",
 			Value:   9092,
 			Usage:   "The port the gRPC server listens on. Set to 0 to disable.",
 			EnvVars: []string{"BAZEL_REMOTE_GRPC_PORT"},
+		},
+		&cli.StringFlag{
+			Name:    "grpc_socket",
+			Value:   "",
+			Usage:   "Unix domain socket path the gRPC server listens on. Takes precedence over gRPC port.",
+			EnvVars: []string{"BAZEL_REMOTE_GRPC_SOCKET"},
 		},
 		&cli.StringFlag{
 			Name:    "profile_host",


### PR DESCRIPTION
This change proposes support for configuring bazel-remote's HTTP and/or gRPC servers to listen on a Unix domain socket, rather than a TCP port. The proposed implementation will prefer the socket config options over host/port when available (this plays nicely with the current behavior of selecting a default port when no port is provided explicitly).

This is useful in contexts where bazel-remote is running behind a reverse proxy, obviating the need for a TCP listener in favor of local IPC.

---

Some manual tests:

```bash
# Default port still works
$ bazelisk run //:bazel-remote -- --dir /tmp/cache --max_size 50
...
$ curl -i localhost:8080/status
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sun, 28 Nov 2021 20:10:55 GMT
Content-Length: 211

{
 "CurrSize": 0,
 "UncompressedSize": 0,
 "ReservedSize": 0,
 "MaxSize": 53687091200,
 "NumFiles": 0,
 "ServerTime": 1638130255,
 "GitCommit": "d146119bb6155c2bb6e50d402a30a6d2c4cc554c",
 "NumGoroutines": 28
}
```

```bash
# TCP port override
$ bazelisk run //:bazel-remote -- --dir /tmp/cache --max_size 50 --host localhost --port 5000
...
$ curl -i localhost:8080/status
curl: (7) Failed to connect to localhost port 8080: Connection refused
$ curl -i localhost:5000/status
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sun, 28 Nov 2021 20:15:31 GMT
Content-Length: 211

{
 "CurrSize": 0,
 "UncompressedSize": 0,
 "ReservedSize": 0,
 "MaxSize": 53687091200,
 "NumFiles": 0,
 "ServerTime": 1638130531,
 "GitCommit": "d146119bb6155c2bb6e50d402a30a6d2c4cc554c",
 "NumGoroutines": 28
}
```

```bash
# Unix socket override, disabling TCP listener
$ bazelisk run //:bazel-remote -- --dir /tmp/cache --max_size 50 --socket /tmp/bazel-remote.sock
...
$ curl -i localhost:8080/status
curl: (7) Failed to connect to localhost port 8080: Connection refused
$ curl -i --unix-socket /tmp/bazel-remote.sock http://localhost/status
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sun, 28 Nov 2021 20:16:27 GMT
Content-Length: 211

{
 "CurrSize": 0,
 "UncompressedSize": 0,
 "ReservedSize": 0,
 "MaxSize": 53687091200,
 "NumFiles": 0,
 "ServerTime": 1638130587,
 "GitCommit": "d146119bb6155c2bb6e50d402a30a6d2c4cc554c",
 "NumGoroutines": 28
}
```