### PR TITLE
Add explicit cross compilation build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,21 @@ on:
 
 jobs:
   linux:
-    name: create linux binary
+    name: create linux binaries
     runs-on: ubuntu-20.04
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: build
+      - name: build amd64
         run: |
           set -eu
-          bazelisk build //:bazel-remote
-          bazelisk run --run_under "cp -f " //:bazel-remote $(pwd)/bazel-remote
+          bazelisk build //:bazel-remote-linux-amd64
+          bazelisk run --run_under "cp -f " //:bazel-remote-linux-amd64 $(pwd)/bazel-remote-linux-amd64
+      - name: build arm64
+        run: |
+          set -eu
+          bazelisk build //:bazel-remote-linux-arm64
+          bazelisk run --run_under "cp -f " //:bazel-remote-linux-arm64 $(pwd)/bazel-remote-linux-arm64
       - name: get release URL
         id: get_release
         uses: bruceadams/get-release@v1.2.2
@@ -25,28 +30,43 @@ jobs:
       - name: get release version
         id: release_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - name: upload
+      - name: upload linux amd64
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: bazel-remote
+          asset_path: bazel-remote-linux-amd64
           asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-linux-x86_64
+          asset_content_type: application/octet-stream
+      - name: upload arm64
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: bazel-remote-linux-arm64
+          asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-linux-arm64
           asset_content_type: application/octet-stream
 
   mac:
-    name: create mac binary
+    name: create mac binaries
     runs-on: macos-10.15
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: build
+      - name: build amd64
         run: |
           set -eu
-          bazelisk build //:bazel-remote
-          bazelisk run --run_under "cp -f " //:bazel-remote $(pwd)/bazel-remote
+          bazelisk build //:bazel-remote-darwin-amd64
+          bazelisk run --run_under "cp -f " //:bazel-remote-darwin-amd64 $(pwd)/bazel-remote-darwin-amd64
+      - name: build arm64
+        run: |
+          set -eu
+          bazelisk build //:bazel-remote-darwin-arm64
+          bazelisk run --run_under "cp -f " //:bazel-remote-darwin-arm64 $(pwd)/bazel-remote-darwin-arm64
       - name: get release URL
         id: get_release
         uses: bruceadams/get-release@v1.2.2
@@ -55,13 +75,23 @@ jobs:
       - name: get release version
         id: release_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
-      - name: upload
+      - name: upload amd64
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: bazel-remote
+          asset_path: bazel-remote-darwin-amd64
           asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-darwin-x86_64
+          asset_content_type: application/octet-stream
+      - name: upload arm64
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: bazel-remote-darwin-arm64
+          asset_name: bazel-remote-${{ steps.release_version.outputs.VERSION }}-darwin-arm64
           asset_content_type: application/octet-stream

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,6 +42,50 @@ go_binary(
     x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
 )
 
+go_binary(
+    name = "bazel-remote-linux-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+)
+
+go_binary(
+    name = "bazel-remote-linux-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+)
+
+go_binary(
+    name = "bazel-remote-darwin-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "darwin",
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+)
+
+go_binary(
+    name = "bazel-remote-darwin-arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "darwin",
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+)
+
 # The distroless static container image's nonroot user id.
 BAZEL_REMOTE_USER_ID = 65532
 


### PR DESCRIPTION
This makes it easier to cross compile for amd64/arm64 on linux/darwin.

There's probably a nicer way to do this, but this should do for now.