### PR TITLE
Update io_bazel_rules_docker v0.14.4 -> v0.22.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -201,9 +201,9 @@ go_repository(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "feb53c560be2f97b7d02b23a1738a3154ba89fe630f09a7a838dcad38731b0b8",
-    strip_prefix = "rules_docker-faaa10a72fa9abde070e2a20d6046e9f9b849e9a",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/faaa10a72fa9abde070e2a20d6046e9f9b849e9a.tar.gz"],
+    sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
+    strip_prefix = "rules_docker-0.22.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],
 )
 
 load(
@@ -216,10 +216,6 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
-
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
 
 load(
     "@io_bazel_rules_docker//go:image.bzl",


### PR DESCRIPTION
This fixes a Python 3.10 build[1].  While here also removed `pip_deps` since `py_image`/ `py3_image` are not used.

[1] `collections.MutableMapping` is deprecated and only available via `collections.abc.MutableMapping`: `bazel build //...`
```
INFO: Repository pip_deps instantiated at:
  /home/rbtz/porn/bazel-remote/WORKSPACE:218:15: in <toplevel>
  /home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/io_bazel_rules_docker/repositories/deps.bzl:35:12: in deps
  /home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/io_bazel_rules_docker/repositories/py_repositories.bzl:36:19: in py_deps
Repository rule pip_import defined at:
  /home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/python/pip.bzl:42:29: in <toplevel>
ERROR: Error fetching repository: Traceback (most recent call last):
	File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/python/pip.bzl", line 40, column 13, in _pip_import_impl
		fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))
Error in fail: pip_import failed:  (Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/__main__.py", line 18, in <module>
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 326, in setup
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 157, in _setup_pkg_resources
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/pypi__setuptools_38_2_4/pkg_resources/__init__.py", line 77, in <module>
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/pypi__setuptools_38_2_4/pkg_resources/_vendor/packaging/requirements.py", line 9, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 672, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 632, in _load_backward_compatible
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/pypi__setuptools_38_2_4/pkg_resources/extern/__init__.py", line 43, in load_module
  File "/home/rbtz/.cache/bazel/_bazel_rbtz/6edd49aecf19ae43ee94e39da2616bf7/external/rules_python/tools/piptool.par/pypi__setuptools_38_2_4/pkg_resources/_vendor/pyparsing.py", line 943, in <module>
    
AttributeError: module 'collections' has no attribute 'MutableMapping'
```