### PR TITLE
Add a max proxy blob size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ OPTIONS:
       preexisting blobs in the cache. (default: 9223372036854775807)
       [$BAZEL_REMOTE_MAX_BLOB_SIZE]
 
+   --max_proxy_blob_size value The maximum logical/uncompressed blob size that will
+      be downloaded from proxies. Note that this limit is not applied to
+      preexisting blobs in the cache. (default: 9223372036854775807)
+      [$BAZEL_REMOTE_MAX_PROXY_BLOB_SIZE]
+
    --num_uploaders value When using proxy backends, sets the number of
       Goroutines to process parallel uploads to backend. (default: 100)
       [$BAZEL_REMOTE_NUM_UPLOADERS]

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -124,8 +124,9 @@ func New(dir string, maxSizeBytes int64, opts ...Option) (Cache, error) {
 		dir: dir,
 
 		// Not using config here, to avoid test import cycles.
-		storageMode: casblob.Zstandard,
-		maxBlobSize: math.MaxInt64,
+		storageMode:      casblob.Zstandard,
+		maxBlobSize:      math.MaxInt64,
+		maxProxyBlobSize: math.MaxInt64,
 
 		// Go defaults to a limit of 10,000 operating system threads.
 		// We probably don't need half of those for file removals at

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -1044,7 +1044,7 @@ func (c *diskCache) Contains(ctx context.Context, kind cache.EntryKind, hash str
 
 	if c.proxy != nil {
 		exists, foundSize = c.proxy.Contains(ctx, kind, hash)
-		if exists && !isSizeMismatch(size, foundSize) {
+		if exists && size <= c.maxProxyBlobSize && !isSizeMismatch(size, foundSize) {
 			return true, foundSize
 		}
 	}

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -816,7 +816,7 @@ func (c *diskCache) availableOrTryProxy(kind cache.EntryKind, hash string, size 
 	}
 	err = nil
 
-	if c.proxy != nil {
+	if c.proxy != nil && size <= c.maxProxyBlobSize {
 		if size > 0 {
 			// If we know the size, attempt to reserve that much space.
 			if !locked {
@@ -946,6 +946,7 @@ func (c *diskCache) get(ctx context.Context, kind cache.EntryKind, hash string, 
 		return nil, -1, nil
 	}
 	if foundSize > c.maxProxyBlobSize {
+		r.Close()
 		return nil, -1, nil
 	}
 
@@ -1042,9 +1043,9 @@ func (c *diskCache) Contains(ctx context.Context, kind cache.EntryKind, hash str
 		return true, foundSize
 	}
 
-	if c.proxy != nil {
+	if c.proxy != nil && size <= c.maxProxyBlobSize {
 		exists, foundSize = c.proxy.Contains(ctx, kind, hash)
-		if exists && size <= c.maxProxyBlobSize && !isSizeMismatch(size, foundSize) {
+		if exists && foundSize <= c.maxProxyBlobSize && !isSizeMismatch(size, foundSize) {
 			return true, foundSize
 		}
 	}

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -175,7 +176,7 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCacheI, err := New(cacheDir, BlockSize, WithProxyBackend(new(proxyStub)), WithAccessLogger(testutils.NewSilentLogger()))
+	testCacheI, err := New(cacheDir, BlockSize, WithProxyBackend(new(proxyStub), math.MaxInt64), WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -851,7 +852,7 @@ func TestHttpProxyBackend(t *testing.T) {
 	// Add some overhead for likely CAS blob storage expansion.
 	cacheSize := int64(1024*10) * 2
 
-	testCacheI, err := New(cacheDir, cacheSize, WithProxyBackend(proxy), WithAccessLogger(testutils.NewSilentLogger()))
+	testCacheI, err := New(cacheDir, cacheSize, WithProxyBackend(proxy, math.MaxInt64), WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -914,8 +914,24 @@ func TestHttpProxyBackend(t *testing.T) {
 		t.Fatal("Expected testCache to be empty")
 	}
 
-	// Add the proxy backend and check that we can Get the item.
+	// Add the proxy backend
 	testCache.proxy = proxy
+	testCache.maxProxyBlobSize = 0
+	found, _ = testCache.Contains(ctx, cache.CAS, casHash, blobSize)
+	if found {
+		t.Fatalf("Expected the cache to not contain %s (via the proxy)", casHash)
+	}
+
+	r, fetchedSize, err := testCache.Get(ctx, cache.CAS, casHash, blobSize, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != nil {
+		t.Fatal("Expected the Get to fail")
+	}
+
+	// Wet a larger max proxy blob size and check that we can Get the item.
+	testCache.maxProxyBlobSize = math.MaxInt64
 
 	found, _ = testCache.Contains(ctx, cache.CAS, casHash, blobSize)
 	if !found {
@@ -923,7 +939,7 @@ func TestHttpProxyBackend(t *testing.T) {
 			casHash)
 	}
 
-	r, fetchedSize, err := testCache.Get(ctx, cache.CAS, casHash, blobSize, 0)
+	r, fetchedSize, err = testCache.Get(ctx, cache.CAS, casHash, blobSize, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -176,7 +176,7 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 
 	cacheDir := tempDir(t)
 	defer os.RemoveAll(cacheDir)
-	testCacheI, err := New(cacheDir, BlockSize, WithProxyBackend(new(proxyStub)), WithProxyMaxBlobSize(math.MaxInt64), WithAccessLogger(testutils.NewSilentLogger()))
+	testCacheI, err := New(cacheDir, BlockSize, WithProxyBackend(new(proxyStub)), WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -852,7 +852,7 @@ func TestHttpProxyBackend(t *testing.T) {
 	// Add some overhead for likely CAS blob storage expansion.
 	cacheSize := int64(1024*10) * 2
 
-	testCacheI, err := New(cacheDir, cacheSize, WithProxyBackend(proxy), WithProxyMaxBlobSize(math.MaxInt64), WithAccessLogger(testutils.NewSilentLogger()))
+	testCacheI, err := New(cacheDir, cacheSize, WithProxyBackend(proxy), WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -42,7 +42,7 @@ func WithMaxBlobSize(size int64) Option {
 	}
 }
 
-func WithProxyBackend(proxy cache.Proxy) Option {
+func WithProxyBackend(proxy cache.Proxy, maxProxyBlobSize int64) Option {
 	return func(c *CacheConfig) error {
 		if c.diskCache.proxy != nil && proxy != nil {
 			return fmt.Errorf("Proxy backends may be set only once")
@@ -50,6 +50,7 @@ func WithProxyBackend(proxy cache.Proxy) Option {
 
 		if proxy != nil {
 			c.diskCache.proxy = proxy
+			c.diskCache.maxProxyBlobSize = maxProxyBlobSize
 			c.diskCache.spawnContainsQueueWorkers()
 		}
 

--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -59,6 +59,10 @@ func WithProxyBackend(proxy cache.Proxy) Option {
 
 func WithProxyMaxBlobSize(maxProxyBlobSize int64) Option {
 	return func(c *CacheConfig) error {
+		if maxProxyBlobSize <= 0 {
+			return fmt.Errorf("Invalid MaxProxyBlobSize: %d", maxProxyBlobSize)
+		}
+
 		c.diskCache.maxProxyBlobSize = maxProxyBlobSize
 		return nil
 	}

--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -42,7 +42,7 @@ func WithMaxBlobSize(size int64) Option {
 	}
 }
 
-func WithProxyBackend(proxy cache.Proxy, maxProxyBlobSize int64) Option {
+func WithProxyBackend(proxy cache.Proxy) Option {
 	return func(c *CacheConfig) error {
 		if c.diskCache.proxy != nil && proxy != nil {
 			return fmt.Errorf("Proxy backends may be set only once")
@@ -50,10 +50,16 @@ func WithProxyBackend(proxy cache.Proxy, maxProxyBlobSize int64) Option {
 
 		if proxy != nil {
 			c.diskCache.proxy = proxy
-			c.diskCache.maxProxyBlobSize = maxProxyBlobSize
 			c.diskCache.spawnContainsQueueWorkers()
 		}
 
+		return nil
+	}
+}
+
+func WithProxyMaxBlobSize(maxProxyBlobSize int64) Option {
+	return func(c *CacheConfig) error {
+		c.diskCache.maxProxyBlobSize = maxProxyBlobSize
 		return nil
 	}
 }

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -123,7 +122,7 @@ func TestEverything(t *testing.T) {
 	}
 
 	diskCacheSize := int64(len(casData) + disk.BlockSize)
-	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithProxyMaxBlobSize(math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +280,7 @@ func TestEverything(t *testing.T) {
 	cacheDir2 := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir2)
 
-	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithProxyMaxBlobSize(math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -123,7 +123,7 @@ func TestEverything(t *testing.T) {
 	}
 
 	diskCacheSize := int64(len(casData) + disk.BlockSize)
-	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache, math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithProxyMaxBlobSize(math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestEverything(t *testing.T) {
 	cacheDir2 := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir2)
 
-	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache, math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithProxyMaxBlobSize(math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -122,7 +123,7 @@ func TestEverything(t *testing.T) {
 	}
 
 	diskCacheSize := int64(len(casData) + disk.BlockSize)
-	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err := disk.New(cacheDir, diskCacheSize, disk.WithProxyBackend(proxyCache, math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +281,7 @@ func TestEverything(t *testing.T) {
 	cacheDir2 := testutils.TempDir(t)
 	defer os.RemoveAll(cacheDir2)
 
-	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache), disk.WithAccessLogger(testutils.NewSilentLogger()))
+	diskCache, err = disk.New(cacheDir2, diskCacheSize, disk.WithProxyBackend(proxyCache, math.MaxInt64), disk.WithAccessLogger(testutils.NewSilentLogger()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
 	AccessLogLevel              string                    `yaml:"access_log_level"`
 	MaxBlobSize                 int64                     `yaml:"max_blob_size"`
+	MaxProxyBlobSize            int64                     `yaml:"max_proxy_blob_size"`
 
 	// Fields that are created by combinations of the flags above.
 	ProxyBackend cache.Proxy
@@ -112,7 +113,8 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
 	accessLogLevel string,
-	maxBlobSize int64) (*Config, error) {
+	maxBlobSize int64,
+	maxProxyBlobSize int64) (*Config, error) {
 
 	c := Config{
 		HTTPAddress:                 httpAddress,
@@ -142,6 +144,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 		HTTPWriteTimeout:            httpWriteTimeout,
 		AccessLogLevel:              accessLogLevel,
 		MaxBlobSize:                 maxBlobSize,
+		MaxProxyBlobSize:            maxProxyBlobSize,
 	}
 
 	err := validateConfig(&c)
@@ -176,6 +179,7 @@ func newFromYaml(data []byte) (*Config, error) {
 			NumUploaders:           100,
 			MaxQueuedUploads:       1000000,
 			MaxBlobSize:            math.MaxInt64,
+			MaxProxyBlobSize:       math.MaxInt64,
 			MetricsDurationBuckets: defaultDurationBuckets,
 			AccessLogLevel:         "all",
 		},
@@ -298,6 +302,10 @@ func validateConfig(c *Config) error {
 
 	if c.MaxBlobSize <= 0 {
 		return errors.New("The 'max_blob_size' flag/key must be a positive integer")
+	}
+
+	if c.MaxProxyBlobSize <= 0 {
+		return errors.New("The 'max_proxy_blob_size' flag/key must be a positive integer")
 	}
 
 	if c.GoogleCloudStorage != nil && c.HTTPBackend != nil && c.S3CloudStorage != nil {
@@ -457,5 +465,6 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Duration("http_write_timeout"),
 		ctx.String("access_log_level"),
 		ctx.Int64("max_blob_size"),
+		ctx.Int64("max_proxy_blob_size"),
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,6 +51,7 @@ access_log_level: none
 		NumUploaders:                100,
 		MaxQueuedUploads:            1000000,
 		MaxBlobSize:                 math.MaxInt64,
+		MaxProxyBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets:      []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:              "none",
 	}
@@ -90,6 +91,7 @@ gcs_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -126,6 +128,7 @@ http_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -199,6 +202,7 @@ s3_proxy:
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -229,6 +233,7 @@ profile_address: :7070
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -273,6 +278,7 @@ endpoint_metrics_duration_buckets: [.005, .1, 5]
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{0.005, 0.1, 5},
 		AccessLogLevel:         "all",
 	}
@@ -287,6 +293,7 @@ func TestMetricsDurationBucketsNoDuplicates(t *testing.T) {
 		HTTPAddress:            "localhost:8080",
 		MaxSize:                42,
 		MaxBlobSize:            200,
+		MaxProxyBlobSize:       math.MaxInt64,
 		Dir:                    "/opt/cache-dir",
 		StorageMode:            "uncompressed",
 		MetricsDurationBuckets: []float64{1, 2, 3, 3},
@@ -398,6 +405,7 @@ storage_mode: zstd
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}
@@ -428,6 +436,7 @@ storage_mode: zstd
 		NumUploaders:           100,
 		MaxQueuedUploads:       1000000,
 		MaxBlobSize:            math.MaxInt64,
+		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
 	}

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func run(ctx *cli.Context) error {
 		disk.WithAccessLogger(c.AccessLogger),
 	}
 	if c.ProxyBackend != nil {
-		opts = append(opts, disk.WithProxyBackend(c.ProxyBackend))
+		opts = append(opts, disk.WithProxyBackend(c.ProxyBackend, c.MaxProxyBlobSize))
 	}
 	if c.EnableEndpointMetrics {
 		opts = append(opts, disk.WithEndpointMetrics())

--- a/main.go
+++ b/main.go
@@ -88,10 +88,11 @@ func run(ctx *cli.Context) error {
 	opts := []disk.Option{
 		disk.WithStorageMode(c.StorageMode),
 		disk.WithMaxBlobSize(c.MaxBlobSize),
+		disk.WithProxyMaxBlobSize(c.MaxProxyBlobSize),
 		disk.WithAccessLogger(c.AccessLogger),
 	}
 	if c.ProxyBackend != nil {
-		opts = append(opts, disk.WithProxyBackend(c.ProxyBackend, c.MaxProxyBlobSize))
+		opts = append(opts, disk.WithProxyBackend(c.ProxyBackend))
 	}
 	if c.EnableEndpointMetrics {
 		opts = append(opts, disk.WithEndpointMetrics())

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -158,6 +158,13 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: strconv.FormatInt(math.MaxInt64, 10),
 			EnvVars:     []string{"BAZEL_REMOTE_MAX_BLOB_SIZE"},
 		},
+		&cli.Int64Flag{
+			Name:        "max_proxy_blob_size",
+			Value:       math.MaxInt64,
+			Usage:       "The maximum logical/uncompressed blob size that will be downloaded from proxies. Note that this limit is not applied to preexisting blobs in the cache.",
+			DefaultText: strconv.FormatInt(math.MaxInt64, 10),
+			EnvVars:     []string{"BAZEL_REMOTE_MAX_PROXY_BLOB_SIZE"},
+		},
 		&cli.IntFlag{
 			Name:    "num_uploaders",
 			Value:   100,


### PR DESCRIPTION
When the proxy server is only connected with a slow network link, it's sometimes beneficial not to download large blobs and recompile them locally instead.
With the new maxProxyBlobSize setting, the remote blob is not read when it is larger.