### PR TITLE
Implement unambiguous compressed blobs bytestream upload early return

### DIFF
--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -415,7 +415,11 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 				exists, _ := s.cache.Contains(srv.Context(), cache.CAS, hash, size)
 				if exists {
 					// Blob already exists, return without writing anything.
-					resp.CommittedSize = size
+					if cmp == casblob.Identity {
+						resp.CommittedSize = size
+					} else {
+						resp.CommittedSize = -1
+					}
 					putResult <- io.EOF
 					return
 				}

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -975,7 +975,7 @@ func TestGrpcByteStreamZstdWrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bswResp.CommittedSize != int64(len(compressedBlob)) {
+	if bswResp.CommittedSize != int64(len(compressedBlob)) && bswResp.CommittedSize != -1 {
 		t.Fatalf("Error: expected to write: %d but committed: %d\n",
 			len(testBlob), bswResp.CommittedSize)
 	}


### PR DESCRIPTION
This is an implementation of this REAPI spec update:
https://github.com/bazelbuild/remote-apis/pull/213

Which is part of the solution to this issue:
https://github.com/bazelbuild/bazel/issues/14654