### PR TITLE
Improve GetValidatedActionResult() performance by validating action result blobs in parallel

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -1155,18 +1155,16 @@ func (c *diskCache) GetValidatedActionResult(ctx context.Context, hash string) (
 		}
 
 		for _, f := range tree.Root.GetFiles() {
-			if f.Digest == nil {
-				continue
+			if f.Digest != nil {
+				pendingValidations = append(pendingValidations, f.Digest)
 			}
-			pendingValidations = append(pendingValidations, f.Digest)
 		}
 
 		for _, child := range tree.GetChildren() {
 			for _, f := range child.GetFiles() {
-				if f.Digest == nil {
-					continue
+				if f.Digest != nil {
+					pendingValidations = append(pendingValidations, f.Digest)
 				}
-				pendingValidations = append(pendingValidations, f.Digest)
 			}
 		}
 	}
@@ -1179,16 +1177,16 @@ func (c *diskCache) GetValidatedActionResult(ctx context.Context, hash string) (
 		pendingValidations = append(pendingValidations, result.StderrDigest)
 	}
 
-	if len(pendingValidations) > 0 {
-		missing, err := c.findMissingCasBlobsInternal(ctx, pendingValidations, true)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		if len(missing) > 0 {
-			return nil, nil, nil // aka "not found"
-		}
+	if len(pendingValidations) == 0 {
+		return result, acdata, nil
 	}
 
-	return result, acdata, nil
+	missing, err := c.findMissingCasBlobsInternal(ctx, pendingValidations, true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(missing) > 0 {
+		return nil, nil, nil // aka "not found"
+	}
 }

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -1180,20 +1180,12 @@ func (c *diskCache) GetValidatedActionResult(ctx context.Context, hash string) (
 	}
 
 	if len(pendingValidations) > 0 {
-		cancelableContext, cancel := context.WithCancel(ctx)
-		cacheMiss := false
-
-		onCacheMiss := func() {
-			cacheMiss = true
-			cancel()
-		}
-
-		err = c.findMissingCasBlobsInternal(cancelableContext, pendingValidations, &onCacheMiss)
+		missing, err := c.findMissingCasBlobsInternal(ctx, pendingValidations, true)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		if cacheMiss {
+		if len(missing) > 0 {
 			return nil, nil, nil // aka "not found"
 		}
 	}

--- a/utils/BUILD.bazel
+++ b/utils/BUILD.bazel
@@ -5,4 +5,7 @@ go_library(
     srcs = ["testutils.go"],
     importpath = "github.com/buchgr/bazel-remote/utils",
     visibility = ["//visibility:public"],
+    deps = [
+        "//genproto/build/bazel/remote/execution/v2:go_default_library",
+    ],
 )

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"log"
 	"testing"
+
+	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
 )
 
 // TempDir creates a temporary directory and returns its name. If an error
@@ -36,6 +38,14 @@ func RandomDataAndHash(size int64) ([]byte, string) {
 	hash := sha256.Sum256(data)
 	hashStr := hex.EncodeToString(hash[:])
 	return data, hashStr
+}
+
+func RandomDataAndDigest(size int64) ([]byte, pb.Digest) {
+	data, hash := RandomDataAndHash(size)
+	return data, pb.Digest{
+		Hash:      hash,
+		SizeBytes: size,
+	}
 }
 
 // NewSilentLogger returns a cheap logger that doesn't print anything, useful


### PR DESCRIPTION
Speed up `GetValidatedActionResult()` for proxy backends by validating
result blobs in parallel.

Previous behavior would iterate through result blobs sequentially. An
action with hundreds (or thousands) of result blobs to check at 10-20ms
each could easily run into timeouts for the caller.

Really, this is just reusing some of the functionality that already exists in `FindMissingCasBlobs()`.  As a result, this should also improve performance for the local cache lookups since it is using `findMissingLocalCAS()` to check the local cache in batches.