### PR TITLE
Update objects timestamps on cache hit

### DIFF
--- a/.bazelci/system-test.sh
+++ b/.bazelci/system-test.sh
@@ -84,6 +84,7 @@ rm -rf $test_cache_dir
 	--s3.access_key_id minioadmin \
 	--s3.secret_access_key minioadmin \
 	--s3.disable_ssl \
+	--s3.update_timestamps \
 	> log.stdout 2> log.stderr &
 test_cache_pid=$!
 echo "Test cache pid: $test_cache_pid"
@@ -141,6 +142,7 @@ rm -rf $test_cache_dir
 	--s3.access_key_id minioadmin \
 	--s3.secret_access_key minioadmin \
 	--s3.disable_ssl \
+	--s3.update_timestamps \
 	> log.stdout 2> log.stderr &
 test_cache_pid=$!
 echo "Test cache pid: $test_cache_pid"
@@ -219,6 +221,7 @@ rm -rf $test_cache_dir
 	--s3.access_key_id minioadmin \
 	--s3.secret_access_key minioadmin \
 	--s3.disable_ssl \
+	--s3.update_timestamps \
 	> log.stdout 2> log.stderr &
 test_cache_pid=$!
 echo "Test cache pid: $test_cache_pid"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ OPTIONS:
       backend. (default: false, ie enable TLS/SSL)
       [$BAZEL_REMOTE_S3_DISABLE_SSL]
 
+   --s3.update_timestamps Whether to update timestamps of object on cache
+      hit. (default: false)
+      [$BAZEL_REMOTE_S3_UPDATE_TIMESTAMPS]   
+
    --s3.iam_role_endpoint value Endpoint for using IAM security credentials.
       By default it will look for credentials in the standard locations for the
       AWS platform. Applies to s3 auth method(s): iam_role.

--- a/cache/s3proxy/minio-test-setup.md
+++ b/cache/s3proxy/minio-test-setup.md
@@ -29,7 +29,9 @@ production use.
     	--s3.auth_method access_key \
     	--s3.access_key_id minioadmin \
     	--s3.secret_access_key minioadmin \
-    	--s3.disable_ssl
+    	--s3.disable_ssl  \
+        --s3.update_timestamps
+
 
 ## Build something with the bazel-remote cache
 

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -206,8 +206,9 @@ func (c *s3Cache) UpdateModificationTimestamp(ctx context.Context, bucket string
 	}
 
 	dst := minio.CopyDestOptions{
-		Bucket: bucket,
-		Object: object,
+		Bucket:          bucket,
+		Object:          object,
+		ReplaceMetadata: true,
 	}
 
 	_, err := c.mcore.ComposeObject(context.Background(), dst, src)

--- a/config/config.go
+++ b/config/config.go
@@ -415,6 +415,7 @@ func get(ctx *cli.Context) (*Config, error) {
 			AccessKeyID:              ctx.String("s3.access_key_id"),
 			SecretAccessKey:          ctx.String("s3.secret_access_key"),
 			DisableSSL:               ctx.Bool("s3.disable_ssl"),
+			UpdateTimestamps:         ctx.Bool("s3.update_timestamps"),
 			IAMRoleEndpoint:          ctx.String("s3.iam_role_endpoint"),
 			Region:                   ctx.String("s3.region"),
 			AWSProfile:               ctx.String("s3.aws_profile"),

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -51,6 +51,7 @@ func (c *Config) setProxy() error {
 			c.S3CloudStorage.Prefix,
 			creds,
 			c.S3CloudStorage.DisableSSL,
+			c.S3CloudStorage.UpdateTimestamps,
 			c.S3CloudStorage.Region,
 			c.StorageMode, c.AccessLogger, c.ErrorLogger, c.NumUploaders, c.MaxQueuedUploads)
 		return nil

--- a/config/s3.go
+++ b/config/s3.go
@@ -17,6 +17,7 @@ type S3CloudStorageConfig struct {
 	AccessKeyID              string `yaml:"access_key_id"`
 	SecretAccessKey          string `yaml:"secret_access_key"`
 	DisableSSL               bool   `yaml:"disable_ssl"`
+	UpdateTimestamps         bool   `yaml:"update_timestamps"`
 	IAMRoleEndpoint          string `yaml:"iam_role_endpoint"`
 	Region                   string `yaml:"region"`
 	KeyVersion               *int   `yaml:"key_version"`

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -249,6 +249,12 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "false, ie enable TLS/SSL",
 			EnvVars:     []string{"BAZEL_REMOTE_S3_DISABLE_SSL"},
 		},
+		&cli.BoolFlag{
+			Name:        "s3.update_timestamps",
+			Usage:       "Whether to update timestamps of object on cache hit.",
+			DefaultText: "false",
+			EnvVars:     []string{"BAZEL_REMOTE_S3_UPDATE_TIMESTAMPS"},
+		},
 		&cli.StringFlag{
 			Name:    "s3.iam_role_endpoint",
 			Value:   "",


### PR DESCRIPTION
In this PR I would like to introduce option to leverage S3 storage lifecycle to automatically remove not used objects after specified amount of time. 
We [can configure S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html) to remove objects after certain amount of time from its modification date. To update modification date, on each cache hit we need to copy object in place - that's limitation of s3. We can now pass `s3.update_timestamps` option in config to use it.
 