### PR TITLE
Make remoteHTTPProxyCache.Contains do HEAD request

### DIFF
--- a/cache/httpproxy/httpproxy.go
+++ b/cache/httpproxy/httpproxy.go
@@ -242,7 +242,7 @@ func (r *remoteHTTPProxyCache) Contains(ctx context.Context, kind cache.EntryKin
 
 	url := r.requestURL(hash, kind)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return false, -1
 	}


### PR DESCRIPTION
As only headers and response status are important and the body is ignored
doing HTTP HEAD will save some network.

Signed-off-by: Anton Tiurin <atiurin@proton.me>