### PR TITLE
Make Go MaxThreads configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	ProfileAddress              string                    `yaml:"profile_address"`
 	Dir                         string                    `yaml:"dir"`
 	MaxSize                     int                       `yaml:"max_size"`
+	MaxThreads                  int                       `yaml:"max_threads"`
 	StorageMode                 string                    `yaml:"storage_mode"`
 	HtpasswdFile                string                    `yaml:"htpasswd_file"`
 	TLSCaFile                   string                    `yaml:"tls_ca_file"`
@@ -91,7 +92,11 @@ var defaultDurationBuckets = []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320}
 
 // newFromArgs returns a validated Config with the specified values, and
 // an error if there were any problems with the validation.
-func newFromArgs(dir string, maxSize int, storageMode string,
+func newFromArgs(
+	dir string,
+	maxSize int,
+	maxThreads int,
+	storageMode string,
 	httpAddress string, grpcAddress string,
 	profileAddress string,
 	htpasswdFile string,
@@ -122,6 +127,7 @@ func newFromArgs(dir string, maxSize int, storageMode string,
 		ProfileAddress:              profileAddress,
 		Dir:                         dir,
 		MaxSize:                     maxSize,
+		MaxThreads:                  maxThreads,
 		StorageMode:                 storageMode,
 		HtpasswdFile:                htpasswdFile,
 		MaxQueuedUploads:            maxQueuedUploads,
@@ -441,6 +447,7 @@ func get(ctx *cli.Context) (*Config, error) {
 	return newFromArgs(
 		ctx.String("dir"),
 		ctx.Int("max_size"),
+		ctx.Int("max_threads"),
 		ctx.String("storage_mode"),
 		httpAddress,
 		grpcAddress,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,6 +16,7 @@ port: 8080
 grpc_port: 9092
 dir: /opt/cache-dir
 max_size: 100
+max_threads: 15000
 htpasswd_file: /opt/.htpasswd
 tls_cert_file: /opt/tls.cert
 tls_key_file:  /opt/tls.key
@@ -38,6 +39,7 @@ access_log_level: none
 		GRPCAddress:                 "localhost:9092",
 		Dir:                         "/opt/cache-dir",
 		MaxSize:                     100,
+		MaxThreads:                  15000,
 		StorageMode:                 "zstd",
 		HtpasswdFile:                "/opt/.htpasswd",
 		TLSCertFile:                 "/opt/tls.cert",

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	_ "net/http/pprof" // Register pprof handlers with DefaultServeMux.
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	auth "github.com/abbot/go-http-auth"
@@ -82,6 +83,11 @@ func run(ctx *cli.Context) error {
 	}
 
 	rlimit.Raise()
+
+	if c.MaxThreads > 0 {
+		log.Printf("Setting MaxThreads to %d", c.MaxThreads)
+		debug.SetMaxThreads(c.MaxThreads)
+	}
 
 	validateAC := !c.DisableHTTPACValidation
 

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -36,6 +36,13 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "The maximum size of the remote cache in GiB. This flag is required.",
 			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE"},
 		},
+		&cli.Int64Flag{
+			Name:        "max_threads",
+			Value:       -1,
+			Usage:       "The maximum number of OS threads the Go service can spawn.",
+			DefaultText: "-1, ie Go defaults kept (see https://pkg.go.dev/runtime/debug#SetMaxThreads)",
+			EnvVars:     []string{"BAZEL_REMOTE_MAX_THREADS"},
+		},
 		&cli.StringFlag{
 			Name:    "storage_mode",
 			Value:   "zstd",


### PR DESCRIPTION
We're running into an issue where threads occassionally back up on IO, leading the service to crash with this error:
```
runtime: program exceeds 10000-thread limit
fatal error: thread exhaustion
```

Our host has sufficient spare memory to handle a much larger number of threads during IO hiccups, so we'd like to configure this value higher.

Is this a change you'd be open to upstreaming?

I've validated the MaxThreads limit gets set locally, but I'm open to also adding an automated test if it seems worthwhile (I'd run the service with `BAZEL_REMOTE_MAX_THREADS=1` and expect a core dump with a `runtime: program exceeds 1-thread limit` error. I'm open to other suggestions). 