### PR TITLE
Modify README.md to reflect valid config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,11 +338,11 @@ max_size: 100
 # be either a hostname or IP address. For Unix domain socket listeners,
 # use unix:///path/to/socket.sock, where /path/to/socket.sock can be
 # either an absolute or relative path to a socket path.
-http_address: localhost:8080
+http_address: 0.0.0.0:8080
 
 # The server listener address for gRPC (unix sockets are also supported
 # as described above):
-#grpc_address: localhost:9092
+#grpc_address: 0.0.0.0:9092
 
 # If profile_address (or the deprecated profile_port and/or profile_host)
 # is specified, then serve /debug/pprof/* URLs here (unix sockets are also


### PR DESCRIPTION
### Description:

- See issue #545.
- Replace "localhost" by "0.0.0.0" in `README.md` which is a setup that avoids the "Connection reset by peer" error when sending requests.
- Unclear whether the `profile_address: 127.0.0.1:7070` should also be modified in the `README.md`?