### PR TITLE
Improve the max_size flag's description, and sync README.md

### DIFF
--- a/.bazelci/buildkite-install-go.sh
+++ b/.bazelci/buildkite-install-go.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-pkg=go1.18.linux-amd64.tar.gz
+pkg=go1.18.2.linux-amd64.tar.gz
 
 wget -o "$HOME/$pkg" "https://golang.org/dl/$pkg" 1>&2
 tar -xv -C "$HOME" -f "$pkg" 1>&2

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ OPTIONS:
    --dir value Directory path where to store the cache contents. This flag is
       required. [$BAZEL_REMOTE_DIR]
 
-   --max_size value The maximum size of the remote cache in GiB. This flag is
-      required. (default: -1) [$BAZEL_REMOTE_MAX_SIZE]
+   --max_size value The maximum size of bazel-remote's disk cache in GiB.
+      This flag is required. (default: -1) [$BAZEL_REMOTE_MAX_SIZE]
 
    --storage_mode value Which format to store CAS blobs in. Must be one of
       "zstd" or "uncompressed". (default: "zstd") [$BAZEL_REMOTE_STORAGE_MODE]
@@ -221,9 +221,9 @@ OPTIONS:
       preexisting blobs in the cache. (default: 9223372036854775807)
       [$BAZEL_REMOTE_MAX_BLOB_SIZE]
 
-   --max_proxy_blob_size value The maximum logical/uncompressed blob size that will
-      be downloaded from proxies. Note that this limit is not applied to
-      preexisting blobs in the cache. (default: 9223372036854775807)
+   --max_proxy_blob_size value The maximum logical/uncompressed blob size
+      that will be downloaded from proxies. Note that this limit is not applied
+      to preexisting blobs in the cache. (default: 9223372036854775807)
       [$BAZEL_REMOTE_MAX_PROXY_BLOB_SIZE]
 
    --num_uploaders value When using proxy backends, sets the number of
@@ -281,8 +281,7 @@ OPTIONS:
       [$BAZEL_REMOTE_S3_DISABLE_SSL]
 
    --s3.update_timestamps Whether to update timestamps of object on cache
-      hit. (default: false)
-      [$BAZEL_REMOTE_S3_UPDATE_TIMESTAMPS]   
+      hit. (default: false) [$BAZEL_REMOTE_S3_UPDATE_TIMESTAMPS]
 
    --s3.iam_role_endpoint value Endpoint for using IAM security credentials.
       By default it will look for credentials in the standard locations for the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,7 +22,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.18")
+go_register_toolchains(version = "1.18.2")
 
 http_archive(
     name = "rules_proto",

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -243,7 +243,7 @@ func (c *diskCache) updateCacheAgeMetric() {
 			log.Printf("ERROR: failed to determine time of least recently used cache item: %v, unable to stat %s", err, f)
 			validAge = false
 		} else {
-			age = time.Now().Sub(ts).Seconds()
+			age = time.Since(ts).Seconds()
 		}
 	}
 

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -33,7 +33,7 @@ func GetCliFlags() []cli.Flag {
 		&cli.Int64Flag{
 			Name:    "max_size",
 			Value:   -1,
-			Usage:   "The maximum size of the remote cache in GiB. This flag is required.",
+			Usage:   "The maximum size of bazel-remote's disk cache in GiB. This flag is required.",
 			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
The help text in README.md was generated with this command:
COLUMNS=80 ./bazel-remote -h