### PR TITLE
Set log flags before logging anything

### DIFF
--- a/config/logger.go
+++ b/config/logger.go
@@ -7,14 +7,12 @@ import (
 )
 
 const (
-	logFlags = log.Ldate | log.Ltime | log.LUTC
+	LogFlags = log.Ldate | log.Ltime | log.LUTC
 )
 
 func (c *Config) setLogger() error {
-	log.SetFlags(logFlags)
-
-	c.AccessLogger = log.New(os.Stdout, "", logFlags)
-	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
+	c.AccessLogger = log.New(os.Stdout, "", LogFlags)
+	c.ErrorLogger = log.New(os.Stderr, "", LogFlags)
 
 	if c.AccessLogLevel == "none" {
 		c.AccessLogger.SetOutput(ioutil.Discard)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ import (
 var gitCommit string
 
 func main() {
+	log.SetFlags(config.LogFlags)
+
 	maybeGitCommitMsg := ""
 	if len(gitCommit) > 0 && gitCommit != "{STABLE_GIT_COMMIT}" {
 		maybeGitCommitMsg = fmt.Sprintf(" from git commit %s", gitCommit)


### PR DESCRIPTION
Previously the "bazel-remote built with... " log line used the default (local?) timezone, then at a later point the config was processed and subsequent logs use UTC, causing an apparent jump in times if the local timezone wasn't also UTC.

We should set the log flags to use UTC before logging anything.

Resolves #564.