### PR TITLE
Shutdown gracefully on sigint (ctrl-c) and sigterm

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "@com_github_urfave_cli_v2//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -56,7 +56,8 @@ var readOnlyMethods = map[string]struct{}{
 // address. This function either returns an error quickly, or triggers a
 // blocking call to https://godoc.org/google.golang.org/grpc#Server.Serve
 func ListenAndServeGRPC(
-	network string, addr string, opts []grpc.ServerOption,
+	srv *grpc.Server,
+	network string, addr string,
 	validateACDeps bool,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
@@ -67,16 +68,15 @@ func ListenAndServeGRPC(
 		return err
 	}
 
-	return serveGRPC(listener, opts, validateACDeps, mangleACKeys, enableRemoteAssetAPI, c, a, e)
+	return serveGRPC(listener, srv, validateACDeps, mangleACKeys, enableRemoteAssetAPI, c, a, e)
 }
 
-func serveGRPC(l net.Listener, opts []grpc.ServerOption,
+func serveGRPC(l net.Listener, srv *grpc.Server,
 	validateACDepsCheck bool,
 	mangleACKeys bool,
 	enableRemoteAssetAPI bool,
 	c disk.Cache, a cache.Logger, e cache.Logger) error {
 
-	srv := grpc.NewServer(opts...)
 	s := &grpcServer{
 		cache: c, accessLogger: a, errorLogger: e,
 		depsCheck:    validateACDepsCheck,

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -98,7 +98,7 @@ func TestMain(m *testing.M) {
 	go func() {
 		err2 := serveGRPC(
 			listener,
-			[]grpc.ServerOption{},
+			grpc.NewServer(),
 			validateAC,
 			mangleACKeys,
 			enableRemoteAssetAPI,


### PR DESCRIPTION
For now, the grpc service (if running) is gracefully stopped first, then the http service is gracefully stopped.