### PR TITLE
Fix AC key mangling for grpc server

### DIFF
--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -204,6 +204,11 @@ func (s *grpcServer) UpdateActionResult(ctx context.Context,
 	req *pb.UpdateActionResultRequest) (*pb.ActionResult, error) {
 
 	logPrefix := "GRPC AC PUT"
+
+	if s.mangleACKeys {
+		req.ActionDigest.Hash = cache.TransformActionCacheKey(req.ActionDigest.Hash, req.InstanceName, s.accessLogger)
+	}
+
 	err := s.validateHash(req.ActionDigest.Hash, req.ActionDigest.SizeBytes, logPrefix)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
https://github.com/buchgr/bazel-remote/pull/339 implemented AC key mangling based on instance name. However, that implementation missed applying the mangling logic on grpc UpdateActionResult method, causing cached entries to not match the ones fetched by GetActionResult. Correctly implement the feature on that method and add test to verify the new behavior.