### PR TITLE
always allow health check requests, even when using mTLS

### DIFF
--- a/.bazelci/tls-tests.sh
+++ b/.bazelci/tls-tests.sh
@@ -37,7 +37,7 @@ generate_keys() {
 
 	# Add subjectAltName aka "SAN", which replaces CN.
 	# Required for Go >= 1.15.
-	cat << EOF > domain.ext
+	cat << EOF > "$tmpdir/domain.ext"
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
@@ -48,7 +48,7 @@ EOF
 
 	# Self-signed server certificate:
 	openssl x509 -req -passin pass:1111 -days 358000 -in "$tmpdir/server.csr" \
-		-extfile domain.ext \
+		-extfile "$tmpdir/domain.ext" \
 		-CA "$tmpdir/ca.crt" -CAkey "$tmpdir/ca.key" -set_serial 01 -out "$tmpdir/server.crt"
 
 	# Remove passphrase from server key:

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -255,7 +255,7 @@ func (c *diskCache) Put(ctx context.Context, kind cache.EntryKind, hash string, 
 			os.Remove(blobFile)
 		} else if blobFile != "" {
 			// Mark the file as "complete".
-			err := os.Chmod(blobFile, tempfile.EndMode)
+			err := os.Chmod(blobFile, tempfile.FinalMode)
 			if err != nil {
 				log.Println("Failed to mark", blobFile, "as complete:", err)
 			}
@@ -583,7 +583,7 @@ func (c *diskCache) get(ctx context.Context, kind cache.EntryKind, hash string, 
 			os.Remove(blobFile)
 		} else if blobFile != "" {
 			// Mark the file as "complete".
-			err := os.Chmod(blobFile, tempfile.EndMode)
+			err := os.Chmod(blobFile, tempfile.FinalMode)
 			if err != nil {
 				log.Println("Failed to mark", blobFile, "as complete:", err)
 			}

--- a/config/tls.go
+++ b/config/tls.go
@@ -27,19 +27,16 @@ func (c *Config) setTLSConfig() error {
 			return fmt.Errorf("Error reading certificate/key pair: %w", err)
 		}
 
-		var cat tls.ClientAuthType = tls.RequireAndVerifyClientCert
-		if c.AllowUnauthenticatedReads {
-			// This allows us to handle some requests without a valid client
-			// certificate, but then we need to explicitly check for verified
-			// certs on requests that we require auth for.
-			// See server.checkGRPCClientCert and httpCache.hasValidClientCert.
-			cat = tls.VerifyClientCertIfGiven
-		}
-
 		c.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{readCert},
 			ClientCAs:    caCertPool,
-			ClientAuth:   cat,
+
+			// This allows us to handle some requests without a valid client
+			// certificate (like the grpc health check service), but then we
+			// need to explicitly check for verified certs on requests that
+			// we require auth for.
+			// See server.checkGRPCClientCert and httpCache.hasValidClientCert.
+			ClientAuth: tls.VerifyClientCertIfGiven,
 		}
 
 		return nil

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -211,10 +211,7 @@ func GRPCmTLSUnaryServerInterceptor(allowUnauthenticatedReads bool) grpc.UnarySe
 }
 
 // Return a non-nil grpc error if a valid client certificate can't be
-// extracted from ctx.
-//
-// This is only used when mutual TLS authentication and unauthenticated
-// reads are enabled.
+// extracted from ctx. This is only used with mTLS authentication.
 func checkGRPCClientCert(ctx context.Context) error {
 
 	p, ok := peer.FromContext(ctx)

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -37,7 +37,7 @@ func TestDownloadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
@@ -105,7 +105,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -169,7 +169,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -210,7 +210,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -252,8 +252,9 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	}
 	validate := true
 	mangle := false
-	unauthenticatedReads := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
+	checkClientCertForReads := false
+	checkClientCertForWrites := false
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -313,8 +314,9 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	}
 	validate := true
 	mangle := false
-	unauthenticatedReads := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, unauthenticatedReads, "")
+	checkClientCertForReads := false
+	checkClientCertForWrites := false
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -337,7 +339,7 @@ func TestStatusPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -481,7 +483,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, "")
+	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))

--- a/utils/grpcreadclient/grpcreadclient.go
+++ b/utils/grpcreadclient/grpcreadclient.go
@@ -287,11 +287,11 @@ func checkBatchReadBlobs(casClient pb.ContentAddressableStorageClient, shouldWor
 	}
 
 	if brResp.Responses[0] == nil {
-		return fmt.Errorf("Error: found nil reponse")
+		return fmt.Errorf("Error: found nil response")
 	}
 
 	if brResp.Responses[0].Status.Code != int32(codes.OK) {
-		return fmt.Errorf("Error: unexpected reponse: %s",
+		return fmt.Errorf("Error: unexpected response: %s",
 			brResp.Responses[0].Status.GetMessage())
 	}
 
@@ -514,15 +514,15 @@ func checkBatchUpdateBlobs(casClient pb.ContentAddressableStorageClient, shouldW
 
 	rs := resp.GetResponses()
 	if len(rs) != 1 {
-		return fmt.Errorf("Expected BatchUpdateBlobs to have 1 reponse, found %d", len(rs))
+		return fmt.Errorf("Expected BatchUpdateBlobs to have 1 response, found %d", len(rs))
 	}
 
 	if rs[0].Digest.Hash != ur.Digest.Hash {
-		return fmt.Errorf("Unexpected digest in reponse")
+		return fmt.Errorf("Unexpected digest in response")
 	}
 
 	if rs[0].Digest.SizeBytes != ur.Digest.SizeBytes {
-		return fmt.Errorf("Unexpected digest in reponse")
+		return fmt.Errorf("Unexpected digest in response")
 	}
 
 	if rs[0].Status != nil && rs[0].Status.Code != int32(codes.OK) {

--- a/utils/grpcreadclient/grpcreadclient.go
+++ b/utils/grpcreadclient/grpcreadclient.go
@@ -253,6 +253,13 @@ func checkCacheReadOps(conn *grpc.ClientConn, shouldWork bool) error {
 		return err
 	}
 
+	healthClient := grpc_health_v1.NewHealthClient(conn)
+
+	err = checkHealth(healthClient) // This should always work.
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -440,13 +447,6 @@ func checkCacheWriteOps(conn *grpc.ClientConn, shouldWork bool) error {
 	bsClient := bytestream.NewByteStreamClient(conn)
 
 	err = checkBytestreamWrite(bsClient, shouldWork)
-	if err != nil {
-		return err
-	}
-
-	healthClient := grpc_health_v1.NewHealthClient(conn)
-
-	err = checkHealth(healthClient) // This should always work.
 	if err != nil {
 		return err
 	}

--- a/utils/grpcreadclient/grpcreadclient.go
+++ b/utils/grpcreadclient/grpcreadclient.go
@@ -612,6 +612,7 @@ func checkHealth(healthClient grpc_health_v1.HealthClient) error {
 	if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
 		return fmt.Errorf("Expected health check to return SERVING status, got: %s", resp.Status.String())
 	}
+	fmt.Println("Health check succeeded, as expected")
 
 	return nil
 }

--- a/utils/tempfile/tempfile.go
+++ b/utils/tempfile/tempfile.go
@@ -35,8 +35,13 @@ func (c *Creator) ranqd1() string {
 
 const flags = os.O_RDWR | os.O_CREATE | os.O_EXCL
 
-const EndMode = 0666
-const wipMode = EndMode | os.ModeSetgid
+// The final permissions of the cache files, once they have finished
+// being uploaded.
+const FinalMode = 0664
+
+// The permissions to use for cache files that are still being uploaded.
+// The setgid bit will be unset when the upload has finished.
+const wipMode = FinalMode | os.ModeSetgid
 
 var errNoTempfile = errors.New("Failed to create a temp file")
 
@@ -48,7 +53,7 @@ var errNoTempfile = errors.New("Failed to create a temp file")
 // wrong.
 //
 // Once the file has been successfully written by the caller, it
-// should be chmod'ed to `EndMode` to mark it as complete.
+// should be chmod'ed to `FinalMode` to mark it as complete.
 func (c *Creator) Create(base string, legacy bool) (*os.File, string, error) {
 	var err error
 	var f *os.File


### PR DESCRIPTION
Previously if bazel-remote was using mTLS authentication but without `--allow_unauthenticated_reads` then it would use the `tls.RequireAndVerifyClientCert` setting which prevented unauthenticated access to the health check service. We want to always allow access to the health check service regardless of authentication status.

Fixes #590.