### PR TITLE
Bump rules_go and gazelle

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,19 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "16e9fca53ed6bd4ff4ad76facc9b7b651a89db1689a2877d6fd7b82aa824e366",
+    sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "501deb3d5695ab658e82f6f6f549ba681ea3ca2a5fb7911154b5aa45596183fa",
+    sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.26.0/bazel-gazelle-v0.26.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
     ],
 )
 
@@ -51,10 +51,10 @@ gazelle_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "59536e6ae64359b716ba9c46c39183403b01eabfbd57578e84398b4829ca499a",
-    strip_prefix = "rules_docker-0.22.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.22.0/rules_docker-v0.22.0.tar.gz"],
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
+
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,7 +55,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
-
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",


### PR DESCRIPTION
I tried to bump `rules_go` and `gazelle` to the most recent versions but I could not build it because of a toolchain issue.
I think it's because of my Mac M1.

This is the error I see but it might be working on your machine or CI:
```
➜  bazel-remote git:(bump-tooling) docker/push_to_dockerhub
INFO: Build option --incompatible_enable_cc_toolchain_resolution has changed, discarding analysis cache.
ERROR: /private/var/tmp/_bazel_fmangione/5371a928ee6ff673886a72c10660bfcb/external/io_bazel_rules_go/BUILD.bazel:86:17: While resolving toolchains for target @io_bazel_rules_go//:cgo_context_data: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type. Maybe --incompatible_use_cc_configure_from_rules_cc has been flipped and there is no default C++ toolchain added in the WORKSPACE file? See https://github.com/bazelbuild/bazel/issues/10134 for details and migration instructions.
ERROR: Analysis of target '//:push_to_dockerhub_amd64' failed; build aborted:
INFO: Elapsed time: 0.975s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 9781 targets configured)
FAILED: Build did NOT complete successfully (0 packages loaded, 9781 targets configured)
    Fetching @com_github_google_go_containerregistry; Restarting.
    Fetching @com_github_pkg_errors; Restarting.
    Fetching @bazel_gazelle_go_repository_config; Restarting.
    Fetching @local_config_cc; Building xcode-locator
    Fetching @bazel_gazelle_go_repository_tools; fetching
    Fetching @com_github_slok_go_http_metrics; Restarting.
    Fetching @com_github_grpc_ecosystem_go_grpc_prometheus; Restarting.
    Fetching @com_github_prometheus_client_golang; Restarting. ... (12 fetches)

```

It seems to be fine on the PR CI build
