### PR TITLE
Try to use a cgo base container image without openssl

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -102,6 +102,7 @@ BAZEL_REMOTE_USER_ID = 65532
 
 go_image(
     name = "bazel-remote-base",
+    base = "@cgo_amd64_base//image",  # Does not include openssl.
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",
@@ -113,6 +114,7 @@ go_image(
 
 go_image(
     name = "bazel-remote-base-arm64",
+    base = "@cgo_arm64_base//image",  # Does not include openssl.
     embed = [":go_default_library"],
     goarch = "arm64",
     goos = "linux",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,6 +67,27 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 container_deps()
 
 load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "cgo_amd64_base",
+    registry = "gcr.io",
+    repository = "distroless/preview/base-nossl-debian11",
+    # See https://github.com/buchgr/bazel-remote/issues/605 and https://github.com/GoogleContainerTools/distroless/issues/1098
+    # TODO: specify this by digest instead? Where can I find that?
+    tag = "nonroot-amd64",
+)
+
+container_pull(
+    name = "cgo_arm64_base",
+    registry = "gcr.io",
+    repository = "distroless/preview/base-nossl-debian11",
+    tag = "nonroot-arm64",
+)
+
+load(
     "@io_bazel_rules_docker//go:image.bzl",
     _go_image_repos = "repositories",
 )


### PR DESCRIPTION
Since we enabled cgo, the docker container images switched to use a distroless base image with glibc and openssl. We want to avoid thinking about openssl security issues/upgrades, especially since bazel-remote doesn't use openssl (go has its own TLS implementation).

There is work-in-progress distroless PR to add "base-nossl-debian11" images, which do not include openssl. Let's try it out:
https://github.com/GoogleContainerTools/distroless/issues/1098

Here are two test images, amd64:
https://hub.docker.com/layers/mostynb/bazel-remote-cache/no-openssl-amd64/images/sha256-a66cf03d5ad1b766018bdb90190840e1f174e13aeee89dc9545c97cb88304d74?context=repo
And arm64:
https://hub.docker.com/layers/mostynb/bazel-remote-cache/no-openssl-arm64/images/sha256-dfa958aa54826b3f2d42b9cefe6314c9694099f4a516ee9c6f557c503ddd11e6?context=repo

Relates to #605.