### PR TITLE
Advertise support up to REAPI version 2.3

### DIFF
--- a/server/grpc.go
+++ b/server/grpc.go
@@ -124,7 +124,7 @@ func (s *grpcServer) GetCapabilities(ctx context.Context,
 			SupportedBatchUpdateCompressors: []pb.Compressor_Value{pb.Compressor_ZSTD},
 		},
 		LowApiVersion:  &semver.SemVer{Major: int32(2)},
-		HighApiVersion: &semver.SemVer{Major: int32(2), Minor: int32(1)},
+		HighApiVersion: &semver.SemVer{Major: int32(2), Minor: int32(3)},
 	}
 
 	s.accessLogger.Printf("GRPC GETCAPABILITIES")


### PR DESCRIPTION
The REAPI features added since v2.1 don't require any changes to bazel-remote. We may as well advertise support for the most recent version.