### PR TITLE
feature: allow setting local timezone for logs (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ OPTIONS:
       logging) [$BAZEL_REMOTE_ACCESS_LOG_LEVEL]
 
    --log_timezone value The timezone to use for log timestamps. If supplied,
-      must be one of "UTC" or "Local". (default: UTC, ie use UTC timezone)
+      must be one of "UTC" or "local". (default: UTC, ie use UTC timezone)
       [$BAZEL_LOG_TIMEZONE]
 
    --help, -h  show help (default: false)

--- a/README.md
+++ b/README.md
@@ -367,8 +367,8 @@ OPTIONS:
       logging) [$BAZEL_REMOTE_ACCESS_LOG_LEVEL]
 
    --log_timezone value The timezone to use for log timestamps. If supplied,
-      must be one of "UTC" or "local". (default: UTC, ie use UTC timezone)
-      [$BAZEL_LOG_TIMEZONE]
+      must be one of "UTC", "local" or "none" for no timestamps. (default: UTC,
+      ie use UTC timezone) [$BAZEL_REMOTE_LOG_TIMEZONE]
 
    --help, -h  show help (default: false)
 ```
@@ -514,7 +514,7 @@ http_address: 0.0.0.0:8080
 # If supplied, controls the verbosity of the access logger ("none" or "all"):
 #access_log_level: none
 
-# If supplied, controls the timezone of the access logger ("local" or "UTC"):
+# If supplied, controls the timezone of the access logger ("UTC", "local" or "none"):
 #log_timezone: local
 ```
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ OPTIONS:
       must be one of "none" or "all". (default: all, ie enable full access
       logging) [$BAZEL_REMOTE_ACCESS_LOG_LEVEL]
 
+   --log_timezone value The timezone to use for log timestamps. If supplied,
+      must be one of "UTC" or "Local". (default: UTC, ie use UTC timezone)
+      [$BAZEL_LOG_TIMEZONE]
+
    --help, -h  show help (default: false)
 ```
 
@@ -509,6 +513,9 @@ http_address: 0.0.0.0:8080
 
 # If supplied, controls the verbosity of the access logger ("none" or "all"):
 #access_log_level: none
+
+# If supplied, controls the timezone of the access logger ("local" or "UTC"):
+#log_timezone: local
 ```
 
 ## Docker

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
 	AccessLogLevel              string                    `yaml:"access_log_level"`
+	LogTimezone                 string                    `yaml:"log_timezone"`
 	MaxBlobSize                 int64                     `yaml:"max_blob_size"`
 	MaxProxyBlobSize            int64                     `yaml:"max_proxy_blob_size"`
 
@@ -117,6 +118,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
 	accessLogLevel string,
+	logTimezone string,
 	maxBlobSize int64,
 	maxProxyBlobSize int64) (*Config, error) {
 
@@ -149,6 +151,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,
 		AccessLogLevel:              accessLogLevel,
+		LogTimezone:                 logTimezone,
 		MaxBlobSize:                 maxBlobSize,
 		MaxProxyBlobSize:            maxProxyBlobSize,
 	}
@@ -189,6 +192,7 @@ func newFromYaml(data []byte) (*Config, error) {
 			MaxProxyBlobSize:       math.MaxInt64,
 			MetricsDurationBuckets: defaultDurationBuckets,
 			AccessLogLevel:         "all",
+			LogTimezone:            "UTC",
 		},
 	}
 
@@ -378,6 +382,12 @@ func validateConfig(c *Config) error {
 		return errors.New("'access_log_level' must be set to either \"none\" or \"all\"")
 	}
 
+	switch c.LogTimezone {
+	case "local", "UTC":
+	default:
+		return errors.New("'log_timezone' must be set to either \"local\" or \"utc\"")
+	}
+
 	return nil
 }
 
@@ -510,6 +520,7 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),
 		ctx.String("access_log_level"),
+		ctx.String("log_timezone"),
 		ctx.Int64("max_blob_size"),
 		ctx.Int64("max_proxy_blob_size"),
 	)

--- a/config/config.go
+++ b/config/config.go
@@ -383,9 +383,9 @@ func validateConfig(c *Config) error {
 	}
 
 	switch c.LogTimezone {
-	case "local", "UTC":
+	case "UTC", "local", "none":
 	default:
-		return errors.New("'log_timezone' must be set to either \"UTC\" or \"local\"")
+		return errors.New("'log_timezone' must be set to either \"UTC\", \"local\" or \"none\"")
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -385,7 +385,7 @@ func validateConfig(c *Config) error {
 	switch c.LogTimezone {
 	case "local", "UTC":
 	default:
-		return errors.New("'log_timezone' must be set to either \"local\" or \"utc\"")
+		return errors.New("'log_timezone' must be set to either \"UTC\" or \"local\"")
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ experimental_remote_asset_api: true
 http_read_timeout: 5s
 http_write_timeout: 10s
 access_log_level: none
+log_timezone: local
 `
 
 	config, err := newFromYaml([]byte(yaml))
@@ -56,6 +57,7 @@ access_log_level: none
 		MaxProxyBlobSize:            math.MaxInt64,
 		MetricsDurationBuckets:      []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:              "none",
+		LogTimezone:                 "local",
 	}
 
 	if !reflect.DeepEqual(config, expectedConfig) {
@@ -97,6 +99,7 @@ gcs_proxy:
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -135,6 +138,7 @@ http_proxy:
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -210,6 +214,7 @@ s3_proxy:
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -242,6 +247,7 @@ profile_address: :7070
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -288,6 +294,7 @@ endpoint_metrics_duration_buckets: [.005, .1, 5]
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{0.005, 0.1, 5},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -418,6 +425,7 @@ storage_mode: zstd
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {
@@ -450,6 +458,7 @@ storage_mode: zstd
 		MaxProxyBlobSize:       math.MaxInt64,
 		MetricsDurationBuckets: []float64{.5, 1, 2.5, 5, 10, 20, 40, 80, 160, 320},
 		AccessLogLevel:         "all",
+		LogTimezone:            "UTC",
 	}
 
 	if !cmp.Equal(config, expectedConfig) {

--- a/config/logger.go
+++ b/config/logger.go
@@ -6,11 +6,16 @@ import (
 	"os"
 )
 
-const (
+var (
 	LogFlags = log.Ldate | log.Ltime | log.LUTC
 )
 
 func (c *Config) setLogger() error {
+
+	if c.LogTimezone == "local" {
+		LogFlags = log.Ldate | log.Ltime
+	}
+
 	c.AccessLogger = log.New(os.Stdout, "", LogFlags)
 	c.ErrorLogger = log.New(os.Stderr, "", LogFlags)
 

--- a/config/logger.go
+++ b/config/logger.go
@@ -7,10 +7,17 @@ import (
 )
 
 func (c *Config) setLogger() error {
-	logFlags := log.Ldate | log.Ltime | log.LUTC
-	if c.LogTimezone == "local" {
+
+	var logFlags int
+	switch c.LogTimezone {
+	case "UTC":
+		logFlags = log.Ldate | log.Ltime | log.LUTC
+	case "local":
 		logFlags = log.Ldate | log.Ltime
+	case "none":
+		logFlags = 0
 	}
+
 	log.SetFlags(logFlags)
 
 	c.AccessLogger = log.New(os.Stdout, "", logFlags)

--- a/config/logger.go
+++ b/config/logger.go
@@ -6,18 +6,15 @@ import (
 	"os"
 )
 
-var (
-	LogFlags = log.Ldate | log.Ltime | log.LUTC
-)
-
 func (c *Config) setLogger() error {
-
+	logFlags := log.Ldate | log.Ltime | log.LUTC
 	if c.LogTimezone == "local" {
-		LogFlags = log.Ldate | log.Ltime
+		logFlags = log.Ldate | log.Ltime
 	}
+	log.SetFlags(logFlags)
 
-	c.AccessLogger = log.New(os.Stdout, "", LogFlags)
-	c.ErrorLogger = log.New(os.Stderr, "", LogFlags)
+	c.AccessLogger = log.New(os.Stdout, "", logFlags)
+	c.ErrorLogger = log.New(os.Stderr, "", logFlags)
 
 	if c.AccessLogLevel == "none" {
 		c.AccessLogger.SetOutput(io.Discard)

--- a/main.go
+++ b/main.go
@@ -42,15 +42,6 @@ import (
 var gitCommit string
 
 func main() {
-	log.SetFlags(config.LogFlags)
-
-	maybeGitCommitMsg := ""
-	if len(gitCommit) > 0 && gitCommit != "{STABLE_GIT_COMMIT}" {
-		maybeGitCommitMsg = fmt.Sprintf(" from git commit %s", gitCommit)
-	}
-	log.Printf("bazel-remote built with %s%s.",
-		runtime.Version(), maybeGitCommitMsg)
-
 	app := cli.NewApp()
 
 	cli.AppHelpTemplate = flags.Template
@@ -86,6 +77,13 @@ func run(ctx *cli.Context) error {
 		_ = cli.ShowAppHelp(ctx)
 		os.Exit(1)
 	}
+
+	maybeGitCommitMsg := ""
+	if len(gitCommit) > 0 && gitCommit != "{STABLE_GIT_COMMIT}" {
+		maybeGitCommitMsg = fmt.Sprintf(" from git commit %s", gitCommit)
+	}
+	log.Printf("bazel-remote built with %s%s.",
+		runtime.Version(), maybeGitCommitMsg)
 
 	rlimit.Raise()
 

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -387,7 +387,7 @@ func GetCliFlags() []cli.Flag {
 			Usage:       "The timezone to use for log timestamps. If supplied, must be one of \"UTC\", \"local\" or \"none\" for no timestamps.",
 			Value:       "UTC",
 			DefaultText: "UTC, ie use UTC timezone",
-			EnvVars:     []string{"BAZEL_LOG_TIMEZONE"},
+			EnvVars:     []string{"BAZEL_REMOTE_LOG_TIMEZONE"},
 		},
 	}
 }

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -382,5 +382,12 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "all, ie enable full access logging",
 			EnvVars:     []string{"BAZEL_REMOTE_ACCESS_LOG_LEVEL"},
 		},
+		&cli.StringFlag{
+			Name:        "log_timezone",
+			Usage:       "The timezone to use for log timestamps. If supplied, must be one of \"UTC\" or \"local\".",
+			Value:       "UTC",
+			DefaultText: "UTC, ie use UTC timezone",
+			EnvVars:     []string{"BAZEL_LOG_TIMEZONE"},
+		},
 	}
 }

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -384,7 +384,7 @@ func GetCliFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "log_timezone",
-			Usage:       "The timezone to use for log timestamps. If supplied, must be one of \"UTC\" or \"local\".",
+			Usage:       "The timezone to use for log timestamps. If supplied, must be one of \"UTC\", \"local\" or \"none\" for no timestamps.",
 			Value:       "UTC",
 			DefaultText: "UTC, ie use UTC timezone",
 			EnvVars:     []string{"BAZEL_LOG_TIMEZONE"},


### PR DESCRIPTION
This is #566 with some small fixes, and also adds a `--log_timezone none` value to disable timestamps in logs (which is useful when running bazel-remote as a systemd service, since systemd tracks the timetsamps itself).

Thanks to @shubhindia for implementing this feature.