### PR TITLE
Refactor proxy backend uploads

### DIFF
--- a/cache/azblobproxy/BUILD.bazel
+++ b/cache/azblobproxy/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//cache:go_default_library",
         "//cache/disk/casblob:go_default_library",
+        "//utils/backendproxy:go_default_library",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:go_default_library",
         "@com_github_azure_azure_sdk_for_go_sdk_storage_azblob//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -65,12 +65,13 @@ func (e *Error) Error() string {
 type Proxy interface {
 
 	// Put makes a reasonable effort to asynchronously upload the cache
-	// item identified by `hash` with logical size `size`, whose data is
-	// readable from `rc` to the proxy backend. The data available in
-	// `rc` is in the same format as used by the disk.Cache instance.
+	// item identified by `hash` with logical size `logicalSize` and
+	// `sizeOnDisk` bytes on disk, whose data is readable from `rc` to
+	// the proxy backend. The data available in `rc` is in the same
+	// format as used by the disk.Cache instance.
 	//
 	// This is allowed to fail silently (for example when under heavy load).
-	Put(ctx context.Context, kind EntryKind, hash string, size int64, rc io.ReadCloser)
+	Put(ctx context.Context, kind EntryKind, hash string, logicalSize int64, sizeOnDisk int64, rc io.ReadCloser)
 
 	// Get returns an io.ReadCloser from which the cache item identified by
 	// `hash` can be read, its logical size, and an error if something went

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -325,7 +325,7 @@ func (c *diskCache) Put(ctx context.Context, kind cache.EntryKind, hash string, 
 			log.Println("Failed to proxy Put:", err)
 		} else {
 			// Doesn't block, should be fast.
-			c.proxy.Put(ctx, kind, hash, sizeOnDisk, rc)
+			c.proxy.Put(ctx, kind, hash, size, sizeOnDisk, rc)
 		}
 	}
 

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -230,7 +230,7 @@ func TestCacheGetContainsWrongSizeWithProxy(t *testing.T) {
 // digest {contentsHash, contentsLength}.
 type proxyStub struct{}
 
-func (d proxyStub) Put(ctx context.Context, kind cache.EntryKind, hash string, size int64, rc io.ReadCloser) {
+func (d proxyStub) Put(ctx context.Context, kind cache.EntryKind, hash string, logicalSize int64, sizeOnDisk int64, rc io.ReadCloser) {
 	// Not implemented.
 }
 

--- a/cache/httpproxy/BUILD.bazel
+++ b/cache/httpproxy/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cache:go_default_library",
         "//cache/disk/casblob:go_default_library",
+        "//utils/backendproxy:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],

--- a/cache/s3proxy/BUILD.bazel
+++ b/cache/s3proxy/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//cache:go_default_library",
         "//cache/disk/casblob:go_default_library",
+        "//utils/backendproxy:go_default_library",
         "@com_github_minio_minio_go_v7//:go_default_library",
         "@com_github_minio_minio_go_v7//pkg/credentials:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/utils/backendproxy/BUILD.bazel
+++ b/utils/backendproxy/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["backendproxy.go"],
+    importpath = "github.com/buchgr/bazel-remote/utils/backendproxy",
+    visibility = ["//visibility:public"],
+    deps = ["//cache:go_default_library"],
+)

--- a/utils/backendproxy/backendproxy.go
+++ b/utils/backendproxy/backendproxy.go
@@ -1,0 +1,37 @@
+package backendproxy
+
+import (
+	"io"
+
+	"github.com/buchgr/bazel-remote/cache"
+)
+
+type UploadReq struct {
+	Hash        string
+	LogicalSize int64
+	SizeOnDisk  int64
+	Kind        cache.EntryKind
+	Rc          io.ReadCloser
+}
+
+type Uploader interface {
+	UploadFile(item UploadReq)
+}
+
+func StartUploaders(u Uploader, numUploaders int, maxQueuedUploads int) chan UploadReq {
+	if maxQueuedUploads <= 0 || numUploaders <= 0 {
+		return nil
+	}
+
+	uploadQueue := make(chan UploadReq, maxQueuedUploads)
+
+	for i := 0; i < numUploaders; i++ {
+		go func() {
+			for item := range uploadQueue {
+				u.UploadFile(item)
+			}
+		}()
+	}
+
+	return uploadQueue
+}


### PR DESCRIPTION
Extract duplicated code into utils/backendproxy, and pass both the logical size and size on disk to the proxy backends when uploading.