### PR TITLE
Make bazel-remote packages consumable as a module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 gazelle(
     name = "gazelle",
-    prefix = "github.com/buchgr/bazel-remote",
+    prefix = "github.com/buchgr/bazel-remote/v2",
 )
 
 gazelle(
@@ -21,7 +21,7 @@ gazelle(
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "github.com/buchgr/bazel-remote",
+    importpath = "github.com/buchgr/bazel-remote/v2",
     visibility = ["//visibility:private"],
     deps = [
         "//cache/disk:go_default_library",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ and bazel-remote will automatically enforce this limit as needed, by deleting
 the least recently used files. S3, GCS and experimental Azure blob storage
 proxy backends are also supported.
 
+Note that while bazel-remote is consumable as a go module, we provide no
+guarantees on the stability or backwards compatibility of the APIs. We do
+attempt to keep the standalone executable backwards-compatible between
+releases however, and cache directory format changes are only allowed in
+major version upgrades.
+
 **Project status**: bazel-remote has been serving TBs of cache artifacts per day since April 2018, both on
 commodity hardware and AWS servers. Outgoing bandwidth can exceed 15 Gbit/s on the right AWS instance type.
 

--- a/cache/BUILD.bazel
+++ b/cache/BUILD.bazel
@@ -3,6 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["cache.go"],
-    importpath = "github.com/buchgr/bazel-remote/cache",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache",
     visibility = ["//visibility:public"],
 )

--- a/cache/azblobproxy/BUILD.bazel
+++ b/cache/azblobproxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "auth_methods.go",
         "azblobproxy.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/cache/azblobproxy",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/azblobproxy",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/cache/azblobproxy/azblobproxy.go
+++ b/cache/azblobproxy/azblobproxy.go
@@ -9,9 +9,9 @@ import (
 	"path"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/utils/backendproxy"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/utils/backendproxy"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"

--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "metrics.go",
         "options.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/cache/disk",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/disk",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/cache/disk/casblob/BUILD.bazel
+++ b/cache/disk/casblob/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["casblob.go"],
-    importpath = "github.com/buchgr/bazel-remote/cache/disk/casblob",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/disk/casblob",
     visibility = ["//visibility:public"],
     deps = ["//cache/disk/zstdimpl:go_default_library"],
 )

--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
 )
 
 type CompressionType uint8

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -16,15 +16,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
-	"github.com/buchgr/bazel-remote/utils/tempfile"
-	"github.com/buchgr/bazel-remote/utils/validate"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	"github.com/buchgr/bazel-remote/v2/utils/tempfile"
+	"github.com/buchgr/bazel-remote/v2/utils/validate"
 
 	"github.com/djherbis/atime"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/prometheus/client_golang/prometheus"

--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
-	"github.com/buchgr/bazel-remote/cache/httpproxy"
-	testutils "github.com/buchgr/bazel-remote/utils"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	"github.com/buchgr/bazel-remote/v2/cache/httpproxy"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/prometheus/client_golang/prometheus"

--- a/cache/disk/findmissing.go
+++ b/cache/disk/findmissing.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/cache/disk/findmissing_test.go
+++ b/cache/disk/findmissing_test.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/buchgr/bazel-remote/cache"
-	testutils "github.com/buchgr/bazel-remote/utils"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 	"google.golang.org/protobuf/proto"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 )
 
 func TestFilterNonNIl(t *testing.T) {

--- a/cache/disk/load.go
+++ b/cache/disk/load.go
@@ -15,10 +15,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
-	"github.com/buchgr/bazel-remote/utils/validate"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	"github.com/buchgr/bazel-remote/v2/utils/validate"
 
 	"github.com/djherbis/atime"
 

--- a/cache/disk/metrics.go
+++ b/cache/disk/metrics.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/cache/disk/zstdimpl/BUILD.bazel
+++ b/cache/disk/zstdimpl/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         ],
         "//conditions:default": [],
     }),
-    importpath = "github.com/buchgr/bazel-remote/cache/disk/zstdimpl",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl",
     visibility = ["//visibility:public"],
     deps = [
         "//utils/zstdpool:go_default_library",

--- a/cache/disk/zstdimpl/gozstd.go
+++ b/cache/disk/zstdimpl/gozstd.go
@@ -2,10 +2,12 @@ package zstdimpl
 
 import (
 	"errors"
-	"github.com/buchgr/bazel-remote/utils/zstdpool"
+	"io"
+
+	"github.com/buchgr/bazel-remote/v2/utils/zstdpool"
+
 	"github.com/klauspost/compress/zstd"
 	syncpool "github.com/mostynb/zstdpool-syncpool"
-	"io"
 )
 
 var zstdFastestLevel = zstd.WithEncoderLevel(zstd.SpeedFastest)

--- a/cache/gcsproxy/BUILD.bazel
+++ b/cache/gcsproxy/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["gcsproxy.go"],
-    importpath = "github.com/buchgr/bazel-remote/cache/gcsproxy",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/gcsproxy",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/cache/gcsproxy/gcsproxy.go
+++ b/cache/gcsproxy/gcsproxy.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/httpproxy"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/httpproxy"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"

--- a/cache/httpproxy/BUILD.bazel
+++ b/cache/httpproxy/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["httpproxy.go"],
-    importpath = "github.com/buchgr/bazel-remote/cache/httpproxy",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/httpproxy",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/cache/httpproxy/httpproxy.go
+++ b/cache/httpproxy/httpproxy.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/utils/backendproxy"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/utils/backendproxy"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/cache/httpproxy/httpproxy_test.go
+++ b/cache/httpproxy/httpproxy_test.go
@@ -16,11 +16,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/cache/disk/zstdimpl"
-	testutils "github.com/buchgr/bazel-remote/utils"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 )
 
 type testServer struct {

--- a/cache/s3proxy/BUILD.bazel
+++ b/cache/s3proxy/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "auth_methods.go",
         "s3proxy.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/cache/s3proxy",
+    importpath = "github.com/buchgr/bazel-remote/v2/cache/s3proxy",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"path"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	"github.com/buchgr/bazel-remote/utils/backendproxy"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/utils/backendproxy"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"

--- a/cache/s3proxy/s3proxy_test.go
+++ b/cache/s3proxy/s3proxy_test.go
@@ -3,7 +3,7 @@ package s3proxy
 import (
 	"testing"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 )
 
 func TestObjectKey(t *testing.T) {

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "s3.go",
         "tls.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/config",
+    importpath = "github.com/buchgr/bazel-remote/v2/config",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/config/azblob.go
+++ b/config/azblob.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/buchgr/bazel-remote/cache/azblobproxy"
+
+	"github.com/buchgr/bazel-remote/v2/cache/azblobproxy"
 )
 
 type AzBlobStorageConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/azblobproxy"
-	"github.com/buchgr/bazel-remote/cache/s3proxy"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/azblobproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 
 	"github.com/urfave/cli/v2"
 	yaml "gopkg.in/yaml.v3"

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/buchgr/bazel-remote/cache/azblobproxy"
-	"github.com/buchgr/bazel-remote/cache/gcsproxy"
-	"github.com/buchgr/bazel-remote/cache/httpproxy"
-	"github.com/buchgr/bazel-remote/cache/s3proxy"
+	"github.com/buchgr/bazel-remote/v2/cache/azblobproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/gcsproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/httpproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 )
 
 func (c *Config) setProxy() error {

--- a/config/s3.go
+++ b/config/s3.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buchgr/bazel-remote/cache/s3proxy"
+	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
+
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 

--- a/genproto/build/bazel/remote/asset/v1/BUILD.bazel
+++ b/genproto/build/bazel/remote/asset/v1/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["remote_asset.pb.go"],
-    importpath = "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/asset/v1",
+    importpath = "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/asset/v1",
     visibility = ["//visibility:public"],
     deps = [
         "//genproto/build/bazel/remote/execution/v2:go_default_library",

--- a/genproto/build/bazel/remote/asset/v1/remote_asset.pb.go
+++ b/genproto/build/bazel/remote/asset/v1/remote_asset.pb.go
@@ -6,7 +6,7 @@ package remoteasset
 import (
 	context "context"
 	fmt "fmt"
-	v2 "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	v2 "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"

--- a/genproto/build/bazel/remote/execution/v2/BUILD.bazel
+++ b/genproto/build/bazel/remote/execution/v2/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["remote_execution.pb.go"],
-    importpath = "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2",
+    importpath = "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2",
     visibility = ["//visibility:public"],
     deps = [
         "//genproto/build/bazel/semver:go_default_library",

--- a/genproto/build/bazel/remote/execution/v2/remote_execution.pb.go
+++ b/genproto/build/bazel/remote/execution/v2/remote_execution.pb.go
@@ -22,7 +22,7 @@ package remoteexecution
 
 import (
 	context "context"
-	semver "github.com/buchgr/bazel-remote/genproto/build/bazel/semver"
+	semver "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/semver"
 	proto "github.com/golang/protobuf/proto"
 	any "github.com/golang/protobuf/ptypes/any"
 	duration "github.com/golang/protobuf/ptypes/duration"

--- a/genproto/build/bazel/semver/BUILD.bazel
+++ b/genproto/build/bazel/semver/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["semver.pb.go"],
-    importpath = "github.com/buchgr/bazel-remote/genproto/build/bazel/semver",
+    importpath = "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/semver",
     visibility = ["//visibility:public"],
     deps = ["@com_github_golang_protobuf//proto:go_default_library"],
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buchgr/bazel-remote
+module github.com/buchgr/bazel-remote/v2
 
 require (
 	github.com/abbot/go-http-auth v0.4.1-0.20220112235402-e1cee1c72f2f

--- a/main.go
+++ b/main.go
@@ -15,13 +15,13 @@ import (
 
 	auth "github.com/abbot/go-http-auth"
 
-	"github.com/buchgr/bazel-remote/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
 
-	"github.com/buchgr/bazel-remote/config"
-	"github.com/buchgr/bazel-remote/server"
-	"github.com/buchgr/bazel-remote/utils/flags"
-	"github.com/buchgr/bazel-remote/utils/idle"
-	"github.com/buchgr/bazel-remote/utils/rlimit"
+	"github.com/buchgr/bazel-remote/v2/config"
+	"github.com/buchgr/bazel-remote/v2/server"
+	"github.com/buchgr/bazel-remote/v2/utils/flags"
+	"github.com/buchgr/bazel-remote/v2/utils/idle"
+	"github.com/buchgr/bazel-remote/v2/utils/rlimit"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "grpc_idle_timeout.go",
         "http.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/server",
+    importpath = "github.com/buchgr/bazel-remote/v2/server",
     visibility = ["//visibility:public"],
     deps = [
         "//cache:go_default_library",

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -16,13 +16,13 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
-	asset "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/asset/v1"
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
-	"github.com/buchgr/bazel-remote/genproto/build/bazel/semver"
+	asset "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/asset/v1"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
+	"github.com/buchgr/bazel-remote/v2/genproto/build/bazel/semver"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/utils/validate"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/utils/validate"
 
 	_ "github.com/mostynb/go-grpc-compression/snappy" // Register snappy
 	_ "github.com/mostynb/go-grpc-compression/zstd"   // and zstd support.

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -10,10 +10,10 @@ import (
 	"net"
 	"strings"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/utils/validate"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/utils/validate"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"

--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -15,10 +15,10 @@ import (
 	"google.golang.org/grpc/codes"
 	grpc_status "google.golang.org/grpc/status"
 
-	asset "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/asset/v1"
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	asset "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/asset/v1"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 )
 
 // FetchServer implementation

--- a/server/grpc_asset_test.go
+++ b/server/grpc_asset_test.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"testing"
 
-	asset "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/asset/v1"
-	//pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	asset "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/asset/v1"
+	//pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"google.golang.org/grpc/codes"
 
-	testutils "github.com/buchgr/bazel-remote/utils"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 )
 
 func TestAssetFetchBlob(t *testing.T) {

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -12,12 +12,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
 
 	"github.com/klauspost/compress/zstd"
 
-	"github.com/buchgr/bazel-remote/utils/zstdpool"
+	"github.com/buchgr/bazel-remote/v2/utils/zstdpool"
 	syncpool "github.com/mostynb/zstdpool-syncpool"
 )
 

--- a/server/grpc_cas.go
+++ b/server/grpc_cas.go
@@ -12,9 +12,9 @@ import (
 	grpc_status "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 )
 
 var (

--- a/server/grpc_idle_timeout.go
+++ b/server/grpc_idle_timeout.go
@@ -5,7 +5,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/buchgr/bazel-remote/utils/idle"
+	"github.com/buchgr/bazel-remote/v2/utils/idle"
 )
 
 // GrpcIdleTimer wraps an idle.Timer, and provides gRPC interceptors that

--- a/server/grpc_test.go
+++ b/server/grpc_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	asset "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/asset/v1"
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	asset "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/asset/v1"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/google/uuid"
@@ -27,10 +27,10 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/cache/disk/casblob"
-	testutils "github.com/buchgr/bazel-remote/utils"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 
 	"github.com/klauspost/compress/zstd"
 )

--- a/server/http.go
+++ b/server/http.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/utils/validate"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/utils/validate"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/encoding/protojson"

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/buchgr/bazel-remote/cache"
-	"github.com/buchgr/bazel-remote/cache/disk"
-	"github.com/buchgr/bazel-remote/utils"
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+	"github.com/buchgr/bazel-remote/v2/utils"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/utils/BUILD.bazel
+++ b/utils/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["testutils.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils",
     visibility = ["//visibility:public"],
     deps = [
         "//genproto/build/bazel/remote/execution/v2:go_default_library",

--- a/utils/backendproxy/BUILD.bazel
+++ b/utils/backendproxy/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["backendproxy.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/backendproxy",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/backendproxy",
     visibility = ["//visibility:public"],
     deps = ["//cache:go_default_library"],
 )

--- a/utils/backendproxy/backendproxy.go
+++ b/utils/backendproxy/backendproxy.go
@@ -3,7 +3,7 @@ package backendproxy
 import (
 	"io"
 
-	"github.com/buchgr/bazel-remote/cache"
+	"github.com/buchgr/bazel-remote/v2/cache"
 )
 
 type UploadReq struct {

--- a/utils/flags/BUILD.bazel
+++ b/utils/flags/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "flags.go",
         "usage.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/utils/flags",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/flags",
     visibility = ["//visibility:public"],
     deps = [
         "//cache/azblobproxy:go_default_library",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -6,8 +6,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/buchgr/bazel-remote/cache/azblobproxy"
-	"github.com/buchgr/bazel-remote/cache/s3proxy"
+	"github.com/buchgr/bazel-remote/v2/cache/azblobproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
+
 	"github.com/urfave/cli/v2"
 )
 

--- a/utils/grpcreadclient/BUILD.bazel
+++ b/utils/grpcreadclient/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["grpcreadclient.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/grpcreadclient",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/grpcreadclient",
     visibility = ["//visibility:private"],
     deps = [
         "//genproto/build/bazel/remote/execution/v2:go_default_library",

--- a/utils/grpcreadclient/grpcreadclient.go
+++ b/utils/grpcreadclient/grpcreadclient.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 	"github.com/google/uuid"
 
 	"google.golang.org/genproto/googleapis/bytestream"

--- a/utils/idle/BUILD.bazel
+++ b/utils/idle/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["idle.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/idle",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/idle",
     visibility = ["//visibility:public"],
 )
 

--- a/utils/idle/idle_test.go
+++ b/utils/idle/idle_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/buchgr/bazel-remote/utils/idle"
+	"github.com/buchgr/bazel-remote/v2/utils/idle"
 )
 
 func TestIdleTimer(t *testing.T) {

--- a/utils/rlimit/BUILD.bazel
+++ b/utils/rlimit/BUILD.bazel
@@ -7,6 +7,6 @@ go_library(
         "rlimit_unix.go",
         "rlimit_windows.go",
     ],
-    importpath = "github.com/buchgr/bazel-remote/utils/rlimit",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/rlimit",
     visibility = ["//visibility:public"],
 )

--- a/utils/tempfile/BUILD.bazel
+++ b/utils/tempfile/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["tempfile.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/tempfile",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/tempfile",
     visibility = ["//visibility:public"],
 )
 

--- a/utils/tempfile/tempfile_test.go
+++ b/utils/tempfile/tempfile_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/buchgr/bazel-remote/utils/tempfile"
+	"github.com/buchgr/bazel-remote/v2/utils/tempfile"
 )
 
 func TestTempfileCreator(t *testing.T) {

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 )
 
 // TempDir creates a temporary directory and returns its name. If an error

--- a/utils/validate/BUILD.bazel
+++ b/utils/validate/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["action_result.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/validate",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/validate",
     visibility = ["//visibility:public"],
     deps = ["//genproto/build/bazel/remote/execution/v2:go_default_library"],
 )

--- a/utils/validate/action_result.go
+++ b/utils/validate/action_result.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 )
 
 var (

--- a/utils/validate/action_result_test.go
+++ b/utils/validate/action_result_test.go
@@ -3,7 +3,7 @@ package validate
 import (
 	"testing"
 
-	pb "github.com/buchgr/bazel-remote/genproto/build/bazel/remote/execution/v2"
+	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 )
 
 func TestValidateNilPointers(t *testing.T) {

--- a/utils/zstdpool/BUILD.bazel
+++ b/utils/zstdpool/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["zstdpool.go"],
-    importpath = "github.com/buchgr/bazel-remote/utils/zstdpool",
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/zstdpool",
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_klauspost_compress//zstd:go_default_library",


### PR DESCRIPTION
The new import path is:
github.com/buchgr/bazel-remote/v2

Warning: bazel-remote go packages do not follow semantic versioning rules, since it is primarily intended to be consumed as a standalone executable.

I aim to maintain backwards compatibility for the standalone executable (within each major release), but provide no guarantees on the stability of the packages used internally.

Relates to #635.