### PR TITLE
Make max_size mandatory and remove default value

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -128,7 +128,6 @@ container_image(
     name = "bazel-remote-image",
     architecture = "amd64",
     base = ":bazel-remote-base",
-    cmd = ["--max_size=5"],
     entrypoint = [
         "/app/bazel-remote-base.binary",
         "--http_address=:8080",
@@ -151,7 +150,6 @@ container_image(
     name = "bazel-remote-image-arm64",
     architecture = "arm64",
     base = ":bazel-remote-base-arm64",
-    cmd = ["--max_size=1"],
     entrypoint = [
         "/app/bazel-remote-base-arm64.binary",
         "--http_address=:8080",

--- a/README.md
+++ b/README.md
@@ -538,14 +538,16 @@ size of `5 GiB`.
 # Dockerhub example:
 $ docker pull buchgr/bazel-remote-cache
 $ docker run -u 1000:1000 -v /path/to/cache/dir:/data \
-	-p 9090:8080 -p 9092:9092 buchgr/bazel-remote-cache
+	-p 9090:8080 -p 9092:9092 buchgr/bazel-remote-cache \
+	---max_size=5
 ```
 
 ```bash
 # quay.io example:
 $ docker pull quay.io/bazel-remote/bazel-remote
 $ docker run -u 1000:1000 -v /path/to/cache/dir:/data \
-	-p 9090:8080 -p 9092:9092 quay.io/bazel-remote/bazel-remote
+	-p 9090:8080 -p 9092:9092 quay.io/bazel-remote/bazel-remote \
+	---max_size=5
 ```
 
 Note that you will need to change `/path/to/cache/dir` to a valid directory that is readable
@@ -585,7 +587,7 @@ the maximum size in Gibibytes.
 The command below will build a docker image from source and install it into your local docker registry.
 
 ```bash
-$ bazel run :bazel-remote-image
+$ bazel run :bazel-remote-image -- --max_size=5 --dir=/your/path/to/data
 ```
 
 ### ARM Support
@@ -595,7 +597,7 @@ Bazel remote cache server can be run on an ARM architecture (i.e.: on a Raspberr
 To build for ARM, use:
 
 ```bash
-$ bazel run :bazel-remote-image-arm64
+$ bazel run :bazel-remote-image-arm64 -- --max_size=5 --dir=/your/path/to/data
 ```
 
 ## Build a standalone Linux binary

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -37,10 +37,10 @@ func GetCliFlags() []cli.Flag {
 			EnvVars: []string{"BAZEL_REMOTE_DIR"},
 		},
 		&cli.Int64Flag{
-			Name:    "max_size",
-			Value:   -1,
-			Usage:   "The maximum size of bazel-remote's disk cache in GiB. This flag is required.",
-			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE"},
+			Name:     "max_size",
+			Usage:    "The maximum size of bazel-remote's disk cache in GiB. This flag is required.",
+			EnvVars:  []string{"BAZEL_REMOTE_MAX_SIZE"},
+			Required: true,
 		},
 		&cli.StringFlag{
 			Name:    "storage_mode",


### PR DESCRIPTION
Follow-up to https://github.com/buchgr/bazel-remote/pull/654#discussion_r1170522351 

This PR makes the `--max_size` flag required and removes the default value, making the default behaviour and configuration more predictable. 

@mostynb I couldn't test the `:bazel-remote-image` and its `arm64` variant on my machine, seems it finds no matching toolchain on my laptop (darwin/arm64), meaning I haven't been able to test how to pass the size flag to `bazel run :bazel-remote-image` to update the README. 

If you tell me what's missing, I'd be happy to fix that. 

--- 

```
~/work/bazel-remote  rework-max_size-defaults $ bazel run :bazel-remote-image                                         
ERROR: /private/var/tmp/_bazel_tech/67a5c8228e3eb4092fc57f363bbb18b5/external/io_bazel_rules_go/BUILD.bazel:86:17: While resolving toolchains for target @io_bazel_rules_go//:cgo_context_data: No matching toolchains fou
nd for types @bazel_tools//tools/cpp:toolchain_type.
To debug, rerun with --toolchain_resolution_debug='@bazel_tools//tools/cpp:toolchain_type'
If platforms or toolchains are a new concept for you, we'd encourage reading https://bazel.build/concepts/platforms-intro.
ERROR: Analysis of target '//:bazel-remote-image' failed; build aborted: 
INFO: Elapsed time: 0.188s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
ERROR: Build failed. Not running target
```