### PR TITLE
feat(config,cache/s3proxy): add s3 addressing style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ OPTIONS:
    --s3.bucket value The S3/minio bucket to use when using S3 proxy backend.
       [$BAZEL_REMOTE_S3_BUCKET]
 
+   --s3.bucket_lookup_type value The S3/minio bucket lookup type to use when
+      using S3 proxy backend.  (default: auto, types: auto|dns|path)
+      [$BAZEL_REMOTE_S3_BUCKET_LOOKUP_TYPE]
+
    --s3.prefix value The S3/minio object prefix to use when using S3 proxy
       backend. [$BAZEL_REMOTE_S3_PREFIX]
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ OPTIONS:
       [$BAZEL_REMOTE_S3_BUCKET]
 
    --s3.bucket_lookup_type value The S3/minio bucket lookup type to use when
-      using S3 proxy backend.  (default: auto, types: auto|dns|path)
+      using S3 proxy backend.  (default: auto, Allowed values: auto, dns, path.)
       [$BAZEL_REMOTE_S3_BUCKET_LOOKUP_TYPE]
 
    --s3.prefix value The S3/minio object prefix to use when using S3 proxy
@@ -466,6 +466,7 @@ http_address: 0.0.0.0:8080
 #  bucket: test-bucket
 #  prefix: test-prefix
 #  disable_ssl: true
+#  bucket_lookup_type: auto
 #
 # Provide exactly one auth_method (access_key, iam_role, or credentials_file) and accompanying configuration.
 #

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -49,6 +49,7 @@ func New(
 	// S3CloudStorageConfig struct fields:
 	Endpoint string,
 	Bucket string,
+	BucketLookupType minio.BucketLookupType,
 	Prefix string,
 	Credentials *credentials.Credentials,
 	DisableSSL bool,
@@ -69,7 +70,8 @@ func New(
 
 	// Initialize minio client with credentials
 	opts := &minio.Options{
-		Creds: Credentials,
+		Creds:        Credentials,
+		BucketLookup: BucketLookupType,
 
 		Region: Region,
 		Secure: !DisableSSL,

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//cache/s3proxy:go_default_library",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//:go_default_library",
         "@com_github_azure_azure_sdk_for_go_sdk_azidentity//:go_default_library",
+        "@com_github_minio_minio_go_v7//:go_default_library",
         "@com_github_minio_minio_go_v7//pkg/credentials:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",

--- a/config/config.go
+++ b/config/config.go
@@ -447,6 +447,7 @@ func get(ctx *cli.Context) (*Config, error) {
 		s3 = &S3CloudStorageConfig{
 			Endpoint:                 ctx.String("s3.endpoint"),
 			Bucket:                   ctx.String("s3.bucket"),
+			BucketLookupType:         ctx.String("s3.bucket_lookup_type"),
 			Prefix:                   ctx.String("s3.prefix"),
 			AuthMethod:               ctx.String("s3.auth_method"),
 			AccessKeyID:              ctx.String("s3.access_key_id"),

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 
 	"github.com/urfave/cli/v2"
+	"golang.org/x/exp/slices"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -348,6 +349,11 @@ func validateConfig(c *Config) error {
 
 		if c.S3CloudStorage.KeyVersion != nil && *c.S3CloudStorage.KeyVersion != 2 {
 			return fmt.Errorf("s3.key_version (deprecated) must be 2, found %d", c.S3CloudStorage.KeyVersion)
+		}
+
+		if c.S3CloudStorage.BucketLookupType != "" && !slices.Contains([]string{"auto", "dns", "path"}, c.S3CloudStorage.BucketLookupType) {
+			return fmt.Errorf("s3.bucket_lookup_type must be one of: [auto,dns,path] or be empty, found %s",
+				c.S3CloudStorage.BucketLookupType)
 		}
 	}
 

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -49,6 +49,7 @@ func (c *Config) setProxy() error {
 		c.ProxyBackend = s3proxy.New(
 			c.S3CloudStorage.Endpoint,
 			c.S3CloudStorage.Bucket,
+			c.S3CloudStorage.BucketLookupType,
 			c.S3CloudStorage.Prefix,
 			creds,
 			c.S3CloudStorage.DisableSSL,

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buchgr/bazel-remote/v2/cache/gcsproxy"
 	"github.com/buchgr/bazel-remote/v2/cache/httpproxy"
 	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
+	"github.com/minio/minio-go/v7"
 )
 
 func (c *Config) setProxy() error {
@@ -49,7 +50,7 @@ func (c *Config) setProxy() error {
 		c.ProxyBackend = s3proxy.New(
 			c.S3CloudStorage.Endpoint,
 			c.S3CloudStorage.Bucket,
-			c.S3CloudStorage.BucketLookupType,
+			parseBucketLookupType(c.S3CloudStorage.BucketLookupType),
 			c.S3CloudStorage.Prefix,
 			creds,
 			c.S3CloudStorage.DisableSSL,
@@ -78,4 +79,15 @@ func (c *Config) setProxy() error {
 	}
 
 	return nil
+}
+
+func parseBucketLookupType(typeStr string) minio.BucketLookupType {
+	valMap := map[string]minio.BucketLookupType{
+		"auto": minio.BucketLookupAuto,
+		"dns":  minio.BucketLookupDNS,
+		"path": minio.BucketLookupPath,
+	}
+
+	// also when not found the type, return "auto" type.
+	return valMap[typeStr]
 }

--- a/config/s3.go
+++ b/config/s3.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 
+	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
@@ -24,6 +25,8 @@ type S3CloudStorageConfig struct {
 	KeyVersion               *int   `yaml:"key_version"`
 	AWSProfile               string `yaml:"aws_profile"`
 	AWSSharedCredentialsFile string `yaml:"aws_shared_credentials_file"`
+
+	BucketLookupType minio.BucketLookupType `yaml:"bucket_lookup_type"`
 }
 
 func (s3c S3CloudStorageConfig) GetCredentials() (*credentials.Credentials, error) {

--- a/config/s3.go
+++ b/config/s3.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 
-	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
@@ -25,8 +24,7 @@ type S3CloudStorageConfig struct {
 	KeyVersion               *int   `yaml:"key_version"`
 	AWSProfile               string `yaml:"aws_profile"`
 	AWSSharedCredentialsFile string `yaml:"aws_shared_credentials_file"`
-
-	BucketLookupType minio.BucketLookupType `yaml:"bucket_lookup_type"`
+	BucketLookupType         string `yaml:"bucket_lookup_type"`
 }
 
 func (s3c S3CloudStorageConfig) GetCredentials() (*credentials.Credentials, error) {

--- a/deps.bzl
+++ b/deps.bzl
@@ -1281,8 +1281,8 @@ def go_dependencies():
     go_repository(
         name = "org_golang_x_exp",
         importpath = "golang.org/x/exp",
-        sum = "h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=",
-        version = "v0.0.0-20200224162631-6cc2880d07d6",
+        sum = "h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=",
+        version = "v0.0.0-20230522175609-2e198f4a06a1",
     )
     go_repository(
         name = "org_golang_x_image",

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1
 	github.com/valyala/gozstd v1.19.1
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,12 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.14.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.1 h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=
 github.com/klauspost/cpuid/v2 v2.1.1/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -316,6 +320,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -220,6 +220,12 @@ func GetCliFlags() []cli.Flag {
 			EnvVars: []string{"BAZEL_REMOTE_S3_BUCKET"},
 		},
 		&cli.StringFlag{
+			Name:    "s3.bucket_lookup_type",
+			Value:   "auto",
+			Usage:   "The S3/minio bucket lookup type(auto|dns|path) to use when using S3 proxy backend.",
+			EnvVars: []string{"BAZEL_REMOTE_S3_BUCKET_LOOKUP_TYPE"},
+		},
+		&cli.StringFlag{
 			Name:    "s3.prefix",
 			Value:   "",
 			Usage:   "The S3/minio object prefix to use when using S3 proxy backend.",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -222,7 +222,7 @@ func GetCliFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "s3.bucket_lookup_type",
 			Value:   "auto",
-			Usage:   "The S3/minio bucket lookup type(auto|dns|path) to use when using S3 proxy backend.",
+			Usage:   "The S3/minio bucket lookup type to use when using S3 proxy backend. Allowed values: auto, dns, path.",
 			EnvVars: []string{"BAZEL_REMOTE_S3_BUCKET_LOOKUP_TYPE"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Some S3 providers do not support auto bucket lookup type, need to set it with `path` type or `dns` type. 

Here I added a support to set it in `s3_proxy` filed in configuration to make it reachable.