### PR TITLE
fix http regex string to add support for cas.v2 http requests

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -27,7 +27,7 @@ import (
 	syncpool "github.com/mostynb/zstdpool-syncpool"
 )
 
-var blobNameSHA256 = regexp.MustCompile("^/?(.*/)?(ac/|cas/)([a-f0-9]{64})$")
+var blobNameSHA256 = regexp.MustCompile("^/?(.*/)?(ac/|cas(.v2)?/)([a-f0-9]{64})$")
 
 var decoder, _ = zstd.NewReader(nil) // TODO: raise WithDecoderConcurrency ?
 


### PR DESCRIPTION
Adds support to http.go regex string to allow cas.v2 in http request