### PR TITLE
Http proxy returns content length when uncompressed

### DIFF
--- a/cache/httpproxy/httpproxy.go
+++ b/cache/httpproxy/httpproxy.go
@@ -231,7 +231,7 @@ func (r *remoteHTTPProxyCache) Contains(ctx context.Context, kind cache.EntryKin
 
 	rsp, err := r.remote.Do(req)
 	if err == nil && rsp.StatusCode == http.StatusOK {
-		if kind != cache.CAS {
+		if kind != cache.CAS || !r.v2mode {
 			return true, rsp.ContentLength
 		}
 


### PR DESCRIPTION
This is already the case for s3 and azureblob proxy but not for http (and gcs since it's a wrapper around http proxy)