### PR TITLE
Support HTTP proxy with mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ OPTIONS:
    --http_proxy.url value The base URL to use for a http proxy backend.
       [$BAZEL_REMOTE_HTTP_PROXY_URL]
 
+   --http_proxy.key_file value Path to the key used to autheticate with the
+      proxy backend. Enables mTLS. If this flag is provided, then
+      http_proxy.cert_file must also be passed.
+      [$BAZEL_REMOTE_HTTP_PROXY_KEY_FILE]
+
+   --http_proxy.cert_file value Path to the certificate used to autheticate
+      with the proxy backend. Enables mTLS. If this flag is provided, then
+      http_proxy.key_file must also be passed.
+      [$BAZEL_REMOTE_HTTP_PROXY_CERT_FILE]
+
    --gcs_proxy.bucket value The bucket to use for the Google Cloud Storage
       proxy backend. [$BAZEL_REMOTE_GCS_BUCKET]
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,9 @@ type GoogleCloudStorageConfig struct {
 
 // HTTPBackendConfig stores the configuration for a HTTP proxy backend.
 type HTTPBackendConfig struct {
-	BaseURL string `yaml:"url"`
+	BaseURL  string `yaml:"url"`
+	CertFile string `yaml:"cert_file"`
+	KeyFile  string `yaml:"key_file"`
 }
 
 // Config holds the top-level configuration for bazel-remote.
@@ -339,6 +341,11 @@ func validateConfig(c *Config) error {
 		if c.HTTPBackend.BaseURL == "" {
 			return errors.New("The 'url' field is required for 'http_proxy'")
 		}
+		if c.HTTPBackend.KeyFile != "" || c.HTTPBackend.CertFile != "" {
+			if c.HTTPBackend.KeyFile == "" || c.HTTPBackend.CertFile == "" {
+				return errors.New("To use mTLS with the http proxy, both a key and a certifacte must be provided")
+			}
+		}
 	}
 
 	if c.S3CloudStorage != nil {
@@ -470,7 +477,9 @@ func get(ctx *cli.Context) (*Config, error) {
 	var hc *HTTPBackendConfig
 	if ctx.String("http_proxy.url") != "" {
 		hc = &HTTPBackendConfig{
-			BaseURL: ctx.String("http_proxy.url"),
+			BaseURL:  ctx.String("http_proxy.url"),
+			KeyFile:  ctx.String("http_proxy.key_file"),
+			CertFile: ctx.String("http_proxy.cert_file"),
 		}
 	}
 

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -48,7 +48,7 @@ func (c *Config) setProxy() error {
 			}
 
 			tr := &http.Transport{TLSClientConfig: config}
-			httpClient = &http.Client{Transport: tr}
+			httpClient.Transport = tr
 		}
 
 		proxyCache, err := httpproxy.New(baseURL, c.StorageMode,

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -190,6 +190,18 @@ func GetCliFlags() []cli.Flag {
 			EnvVars: []string{"BAZEL_REMOTE_HTTP_PROXY_URL"},
 		},
 		&cli.StringFlag{
+			Name:    "http_proxy.key_file",
+			Value:   "",
+			Usage:   "Path to the key used to autheticate with the proxy backend. Enables mTLS.",
+			EnvVars: []string{"BAZEL_REMOTE_HTTP_PROXY_KEY_FILE"},
+		},
+		&cli.StringFlag{
+			Name:    "http_proxy.cert_file",
+			Value:   "",
+			Usage:   "Path to the certificate used to autheticate with the proxy backend. Enables mTLS.",
+			EnvVars: []string{"BAZEL_REMOTE_HTTP_PROXY_CERT_FILE"},
+		},
+		&cli.StringFlag{
 			Name:    "gcs_proxy.bucket",
 			Value:   "",
 			Usage:   "The bucket to use for the Google Cloud Storage proxy backend.",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -192,13 +192,13 @@ func GetCliFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "http_proxy.key_file",
 			Value:   "",
-			Usage:   "Path to the key used to autheticate with the proxy backend. Enables mTLS.",
+			Usage:   "Path to the key used to autheticate with the proxy backend. Enables mTLS. If this flag is provided, then http_proxy.cert_file must also be passed.",
 			EnvVars: []string{"BAZEL_REMOTE_HTTP_PROXY_KEY_FILE"},
 		},
 		&cli.StringFlag{
 			Name:    "http_proxy.cert_file",
 			Value:   "",
-			Usage:   "Path to the certificate used to autheticate with the proxy backend. Enables mTLS.",
+			Usage:   "Path to the certificate used to autheticate with the proxy backend. Enables mTLS. If this flag is provided, then http_proxy.key_file must also be passed.",
 			EnvVars: []string{"BAZEL_REMOTE_HTTP_PROXY_CERT_FILE"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
Support passing a key and certificate pair to enable mTLS with the http proxy backend