### PR TITLE
Release actions: upgrade actions/checkout@v2 -> actions/checkout@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: get release version
         id: release_version
         run: echo VERSION=${GITHUB_REF/refs\/tags\/v/} >> $GITHUB_ENV
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: get release version
         id: release_version
         run: echo VERSION=${GITHUB_REF/refs\/tags\/v/} >> $GITHUB_ENV


### PR DESCRIPTION
This will hopefully avoid the use of node12, which is no longer available: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/