### PR TITLE
Fix serving uncompressed blob as compressed

### DIFF
--- a/cache/disk/casblob/BUILD.bazel
+++ b/cache/disk/casblob/BUILD.bazel
@@ -11,4 +11,9 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["casblob_test.go"],
+    deps = [
+        ":go_default_library",
+        "//cache/disk/zstdimpl:go_default_library",
+        "//utils:go_default_library",
+    ],
 )

--- a/cache/disk/casblob/casblob.go
+++ b/cache/disk/casblob/casblob.go
@@ -402,7 +402,7 @@ func GetLegacyZstdReadCloser(zstd zstdimpl.ZstdImpl, f *os.File) (io.ReadCloser,
 
 	pr, pw := io.Pipe()
 
-	enc, err := zstd.GetEncoder(f)
+	enc, err := zstd.GetEncoder(pw)
 	if err != nil {
 		_ = f.Close()
 		return nil, err
@@ -425,7 +425,14 @@ func GetLegacyZstdReadCloser(zstd zstdimpl.ZstdImpl, f *os.File) (io.ReadCloser,
 			log.Println("Error while closing encoder:", err)
 			_ = pw.CloseWithError(err)
 		}
-		_ = f.Close()
+
+		err = f.Close()
+		if err != nil {
+			log.Println("Error while closing file:", err)
+			_ = pw.CloseWithError(err)
+		}
+
+		_ = pw.Close()
 	}()
 
 	return pr, nil

--- a/cache/disk/casblob/casblob_test.go
+++ b/cache/disk/casblob/casblob_test.go
@@ -1,8 +1,18 @@
 package casblob_test
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
 	"testing"
 	"unsafe"
+
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
 )
 
 func TestLenSize(t *testing.T) {
@@ -15,5 +25,57 @@ func TestLenSize(t *testing.T) {
 	if len(slice) != 0 {
 		// We should never hit this case.
 		t.Errorf("This should silence linters that think slice is never used")
+	}
+}
+
+func TestZstdFromLegacy(t *testing.T) {
+	size := 1024
+	zstd, err := zstdimpl.Get("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, hash := testutils.RandomDataAndHash(int64(size))
+	dir := testutils.TempDir(t)
+	filename := fmt.Sprintf("%s/%s", dir, hash)
+	file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0664)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := file.Write(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != size {
+		t.Fatalf("Unexpected short write %d, expected %d", n, size)
+	}
+	file.Close()
+
+	file, err = os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zrc, err := casblob.GetLegacyZstdReadCloser(zstd, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc, err := zstd.GetDecoder(zrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if buf.Len() != size {
+		t.Fatalf("Unexpected buf size %d, expected %d", buf.Len(), size)
+	}
+
+	h := sha256.Sum256(data)
+	hs := hex.EncodeToString(h[:])
+	if hs != hash {
+		t.Fatalf("Unexpected content sha %s, expected %s", hs, hash)
 	}
 }


### PR DESCRIPTION
The pipe is created but never written to nor closed. Instead, the file is passed as writer to the encoder, causing errors like the following when serving zstd compressed blob when using uncompressed storage:
```
2023/08/29 18:58:44 Error while closing encoder: write /private/tmp/cache/cas.v2/4d/4d42748448b9cf8484bfea1e5df65e33213fcc85bba393ae4f3ebebd627523c0-144750847.v1: bad file descriptor
2023/08/29 18:58:44 Error writing cas/4d42748448b9cf8484bfea1e5df65e33213fcc85bba393ae4f3ebebd627523c0 err: write /private/tmp/cache/cas.v2/4d/4d42748448b9cf8484bfea1e5df65e33213fcc85bba393ae4f3ebebd627523c0-144750847.v1: bad file descriptor
2023/08/29 18:58:44  GET 500       127.0.0.1 /cas/4d42748448b9cf8484bfea1e5df65e33213fcc85bba393ae4f3ebebd627523c0
```