### PR TITLE
[metrics] initialize hits/misses for each cache entry kind

### DIFF
--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -98,6 +98,13 @@ func WithEndpointMetrics() Option {
 				[]string{"method", "kind", "status"}),
 		}
 
+		c.metrics.counter.WithLabelValues("get", "cas", "hit").Add(0)
+		c.metrics.counter.WithLabelValues("get", "cas", "miss").Add(0)
+		c.metrics.counter.WithLabelValues("contains", "cas", "hit").Add(0)
+		c.metrics.counter.WithLabelValues("contains", "cas", "miss").Add(0)
+		c.metrics.counter.WithLabelValues("get", "ac", "hit").Add(0)
+		c.metrics.counter.WithLabelValues("get", "ac", "miss").Add(0)
+
 		return nil
 	}
 }


### PR DESCRIPTION
This makes sure all hit/miss counters appear on the metrics endpoints and avoids having to fill missing metrics with zero at the client side.