### PR TITLE
Drop server support for TLS 1.0 and 1.1

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -8,6 +8,12 @@ import (
 )
 
 func (c *Config) setTLSConfig() error {
+
+	// Only use TLS 1.2 or later on the server side. At the time of writing,
+	// go defaults to using 1.0 as the min version when acting as a server.
+	// TODO: consider raising this to 1.3, and possibly add a config flag?
+	minTLSVersion := uint16(tls.VersionTLS12)
+
 	if len(c.TLSCaFile) != 0 {
 		caCertPool := x509.NewCertPool()
 		caCert, err := os.ReadFile(c.TLSCaFile)
@@ -37,6 +43,8 @@ func (c *Config) setTLSConfig() error {
 			// we require auth for.
 			// See server.checkGRPCClientCert and httpCache.hasValidClientCert.
 			ClientAuth: tls.VerifyClientCertIfGiven,
+
+			MinVersion: minTLSVersion,
 		}
 
 		return nil
@@ -53,6 +61,7 @@ func (c *Config) setTLSConfig() error {
 
 		c.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{readCert},
+			MinVersion:   minTLSVersion,
 		}
 
 		return nil


### PR DESCRIPTION
At the time of writing, current go versions default to TLS 1.0 as the minimum version when acting as a server (and 1.2 when acting as a client). This change raises the minium version to 1.2 when acting as a server too.

If this causes trouble, we can consider adding a config flag to specify the minimum TLS version.

Fixes #708.