### PR TITLE
Disable bzlmod explicitly in .bazelrc until we're ready to switch to bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
 # Include git version info
 build --stamp
 build --workspace_status_command 'echo STABLE_GIT_COMMIT $(git rev-parse HEAD)'
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+common --noenable_bzlmod


### PR DESCRIPTION
This should stop bazel7 from creating MODULE.bazel files until we're ready to migrate to bzlmod.