### PR TITLE
feat: support use s3 sign v2 by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,10 @@ OPTIONS:
       using S3 proxy backend. Applies to s3 auth method(s): access_key.
       [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
       
-   --s3.disable_v4_sign Whether to disable v4 sign and enable v2 sign when 
-      using the S3 proxy backend. Only effect when use access_key as 
-      auth_method. (default: false, is enable v4 sign) 
-      [$BAZEL_REMOTE_S3_DISABLE_V4_SIGN]
+   --s3.signature_type value Which type of aws signature will be used when 
+      using S3 proxy backend. Applies to s3 auth method(s): access_key. 
+      Allowed values: s3v2, s3v4, s3v4streaming, anonymous. (default: s3v4) 
+      [$BAZEL_REMOTE_S3_SIGNATURE_TYPE]
 
    --s3.aws_shared_credentials_file value Path to the AWS credentials file.
       If not specified, the minio client will default to '~/.aws/credentials'.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,11 @@ OPTIONS:
    --s3.secret_access_key value The S3/minio secret access key to use when
       using S3 proxy backend. Applies to s3 auth method(s): access_key.
       [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
+      
+   --s3.disable_v4_sign Whether to disable v4 sign and enable v2 sign when 
+      using the S3 proxy backend. Only effect when use access_key as 
+      auth_method. (default: false, is enable v4 sign) 
+      [$BAZEL_REMOTE_S3_DISABLE_V4_SIGN]
 
    --s3.aws_shared_credentials_file value Path to the AWS credentials file.
       If not specified, the minio client will default to '~/.aws/credentials'.

--- a/config/config.go
+++ b/config/config.go
@@ -416,6 +416,13 @@ func validateConfig(c *Config) error {
 			return fmt.Errorf("s3.bucket_lookup_type must be one of: \"auto\", \"dns\", \"path\" or empty/unspecified, found: \"%s\"",
 				c.S3CloudStorage.BucketLookupType)
 		}
+
+		if c.S3CloudStorage.SignatureType != "" && c.S3CloudStorage.SignatureType != "s3v2" &&
+			c.S3CloudStorage.SignatureType != "s3v4" && c.S3CloudStorage.SignatureType != "s3v4streaming" &&
+			c.S3CloudStorage.SignatureType != "anonymous" {
+			return fmt.Errorf("s3.signature_type must be one of: \"s3v2\", \"s3v4\", \"s3v4streaming\", \"anonymous\" or empty/unspecified, found: \"%s\"",
+				c.S3CloudStorage.SignatureType)
+		}
 	}
 
 	if c.AzBlobConfig != nil {
@@ -519,7 +526,7 @@ func get(ctx *cli.Context) (*Config, error) {
 			AuthMethod:               ctx.String("s3.auth_method"),
 			AccessKeyID:              ctx.String("s3.access_key_id"),
 			SecretAccessKey:          ctx.String("s3.secret_access_key"),
-			DisableV4Sign:            ctx.Bool("s3.disable_v4_sign"),
+			SignatureType:            ctx.String("s3.signature_type"),
 			DisableSSL:               ctx.Bool("s3.disable_ssl"),
 			UpdateTimestamps:         ctx.Bool("s3.update_timestamps"),
 			IAMRoleEndpoint:          ctx.String("s3.iam_role_endpoint"),

--- a/config/config.go
+++ b/config/config.go
@@ -519,6 +519,7 @@ func get(ctx *cli.Context) (*Config, error) {
 			AuthMethod:               ctx.String("s3.auth_method"),
 			AccessKeyID:              ctx.String("s3.access_key_id"),
 			SecretAccessKey:          ctx.String("s3.secret_access_key"),
+			DisableV4Sign:            ctx.Bool("s3.disable_v4_sign"),
 			DisableSSL:               ctx.Bool("s3.disable_ssl"),
 			UpdateTimestamps:         ctx.Bool("s3.update_timestamps"),
 			IAMRoleEndpoint:          ctx.String("s3.iam_role_endpoint"),

--- a/config/s3.go
+++ b/config/s3.go
@@ -17,6 +17,7 @@ type S3CloudStorageConfig struct {
 	AuthMethod               string `yaml:"auth_method"`
 	AccessKeyID              string `yaml:"access_key_id"`
 	SecretAccessKey          string `yaml:"secret_access_key"`
+	DisableV4Sign            bool   `yaml:"disable_v4_sign"`
 	DisableSSL               bool   `yaml:"disable_ssl"`
 	UpdateTimestamps         bool   `yaml:"update_timestamps"`
 	IAMRoleEndpoint          string `yaml:"iam_role_endpoint"`
@@ -39,6 +40,11 @@ func (s3c S3CloudStorageConfig) GetCredentials() (*credentials.Credentials, erro
 			return nil, fmt.Errorf("missing s3.secret_access_key for s3.auth_method = '%s'", s3proxy.AuthMethodAccessKey)
 		}
 		log.Println("S3 Credentials: using access/secret access key.")
+		if s3c.DisableV4Sign {
+			log.Println("S3 Sign: using v2 sign")
+			return credentials.NewStaticV2(s3c.AccessKeyID, s3c.SecretAccessKey, ""), nil
+		}
+		log.Println("S3 Sign: using v4 sign")
 		return credentials.NewStaticV4(s3c.AccessKeyID, s3c.SecretAccessKey, ""), nil
 	} else if s3c.AuthMethod == s3proxy.AuthMethodIAMRole {
 		// Fall back to getting credentials from IAM

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -296,6 +296,12 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "The S3/minio secret access key to use when using S3 proxy backend. " + s3AuthMsg(s3proxy.AuthMethodAccessKey),
 			EnvVars: []string{"BAZEL_REMOTE_S3_SECRET_ACCESS_KEY"},
 		},
+		&cli.BoolFlag{
+			Name:        "s3.disable_v4_sign",
+			Usage:       "Whether to disable v4 sign and enable v2 sign when using the S3 proxy backend. Only effect when use access_key as auth_method",
+			DefaultText: "false, is enable v4 sign",
+			EnvVars:     []string{"BAZEL_REMOTE_S3_DISABLE_V4_SIGN"},
+		},
 		&cli.StringFlag{
 			Name:    "s3.aws_shared_credentials_file",
 			Value:   "",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -296,11 +296,11 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "The S3/minio secret access key to use when using S3 proxy backend. " + s3AuthMsg(s3proxy.AuthMethodAccessKey),
 			EnvVars: []string{"BAZEL_REMOTE_S3_SECRET_ACCESS_KEY"},
 		},
-		&cli.BoolFlag{
-			Name:        "s3.disable_v4_sign",
-			Usage:       "Whether to disable v4 sign and enable v2 sign when using the S3 proxy backend. Only effect when use access_key as auth_method",
-			DefaultText: "false, is enable v4 sign",
-			EnvVars:     []string{"BAZEL_REMOTE_S3_DISABLE_V4_SIGN"},
+		&cli.StringFlag{
+			Name:        "s3.signature_type",
+			Usage:       "Which type of s3/minio signature will be used when using S3 proxy backend. Applies to s3 auth method(s): access_key. Allowed values: s3v2, s3v4, s3v4streaming, anonymous.",
+			DefaultText: "s3v4, is using v4 sign",
+			EnvVars:     []string{"BAZEL_REMOTE_S3_SIGNATURE_TYPE"},
 		},
 		&cli.StringFlag{
 			Name:    "s3.aws_shared_credentials_file",


### PR DESCRIPTION
This PR support to set s3 sign as v2. Resolves #725 
Now user could set a new flag --s3.disable_v4_sign=true when there auth_method is secret_key, which will lead using minio/pkg/credentials.NewStaticV2 as the initialization of s3 credential. This can support some situation when s3 do not support v4 sign well.