### PR TITLE
fix infinite recursion with idle timer

### DIFF
--- a/main.go
+++ b/main.go
@@ -253,9 +253,10 @@ func startHttpServer(c *config.Config, httpServer **http.Server,
 	}
 
 	if c.IdleTimeout > 0 {
+		ch := cacheHandler // Avoid an infinite loop in the closure below.
 		cacheHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			idleTimer.ResetTimer()
-			cacheHandler(w, r)
+			ch(w, r)
 		})
 	}
 


### PR DESCRIPTION
Noticed that bazel-remote will crash with a wicked stack trace if you enable the idle-timer.

Tested locally. Not really sure how to write a good test for this.

Repro is pretty easy:
```
root@9b9a2900fc12:/work# ./bazel-remote-without-patch --dir /data --max_size 1 --idle_timeout 1m
```

Separate terminal:
```
root@9b9a2900fc12:/work# curl --head --fail http://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
curl: (52) Empty reply from server
```

Stack trace omitted because it is too large.

With the patch:
```
root@9b9a2900fc12:/work# ./bazel-remote-with-patch --dir /data --max_size 1 --idle_timeout 1m
```

Separate terminal:
```
root@9b9a2900fc12:/work# curl --head --fail http://localhost:8080/cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
HTTP/1.1 200 OK
Content-Length: 0
Date: Thu, 04 Jan 2024 22:39:56 GMT
```

We see the log:
```
2024/01/04 22:39:56 HEAD 200       127.0.0.1 /cas/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```