### PR TITLE
chore: cleanup local build rule and docs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 gazelle(
@@ -132,6 +132,12 @@ oci_image(
     visibility = ["//visibility:public"],
 )
 
+oci_tarball(
+    name = "bazel-remote-image-tarball",
+    image = ":bazel-remote-image",
+    repo_tags = ["buchgr/bazel-remote-cache:tmp-amd64"],
+)
+
 pkg_tar(
     name = "bazel-remote-linux-arm64_tar",
     srcs = [":bazel-remote-linux-arm64"],
@@ -157,6 +163,12 @@ oci_image(
     ],
     user = str(BAZEL_REMOTE_USER_ID),
     visibility = ["//visibility:private"],
+)
+
+oci_tarball(
+    name = "bazel-remote-image-arm64-tarball",
+    image = ":bazel-remote-image-arm64",
+    repo_tags = ["buchgr/bazel-remote-cache:tmp-arm64"],
 )
 
 # The following container_push targets push to "tmp-amd64" and "tmp-arm64"

--- a/README.md
+++ b/README.md
@@ -657,7 +657,8 @@ See [examples/docker-compose.yml](examples/docker-compose.yml) for an example co
 The command below will build a docker image from source and install it into your local docker registry.
 
 ```bash
-$ bazel run :bazel-remote-image -- --max_size 5 --dir /your/path/to/data
+$ bazel build :bazel-remote-image-tarball && docker load -i bazel-bin/bazel-remote-image-tarball/tarball.tar
+$ docker run buchgr/bazel-remote-cache:tmp-amd64 --max_size 5 --dir /your/path/to/data
 ```
 
 ### ARM Support
@@ -667,7 +668,8 @@ Bazel remote cache server can be run on an ARM architecture (i.e.: on a Raspberr
 To build for ARM, use:
 
 ```bash
-$ bazel run :bazel-remote-image-arm64 -- --max_size 5 --dir /your/path/to/data
+$ bazel build :bazel-remote-image-arm64-tarball && docker load -i bazel-bin/bazel-remote-image-arm64-tarball/tarball.tar
+$ docker run buchgr/bazel-remote-cache:tmp-arm64 --max_size 5 --dir /your/path/to/data
 ```
 
 ## Build a standalone Linux binary


### PR DESCRIPTION
`oci_image` is not executable