### PR TITLE
Add a clearer error

### DIFF
--- a/config/proxy.go
+++ b/config/proxy.go
@@ -184,7 +184,7 @@ func parseBucketLookupType(typeStr string) (minio.BucketLookupType, error) {
 
 	val, ok := valMap[typeStr]
 	if !ok {
-		return 0, fmt.Errorf("Unsupported value: %s", typeStr)
+		return 0, fmt.Errorf("Unsupported bucket_lookup_type value : %s", typeStr)
 	}
 
 	return val, nil


### PR DESCRIPTION
I spent 1 hour trying to debug what config was changed when upgrading from old version to newer one. This should give enough clues about where to look for.
I was using the config_file parameter, and the YAML didn't specify `bucket_lookup_type`, which caused the app crashes with  unhelpful text `Unsupported value:`