### PR TITLE
More informative error message in case of corrupted blob headers

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -476,7 +476,7 @@ func (c *diskCache) availableOrTryProxy(kind cache.EntryKind, hash string, size 
 				}
 
 				if err != nil {
-					log.Printf("Warning: expected item to be on disk, but something happened: %v", err)
+					log.Printf("Warning: expected item to be on disk, but something happened when retrieving %s (compressed: %v, legacy: %v): %v", blobPath, item.legacy, zstd, err)
 					f.Close()
 				} else {
 					return rc, item.size, false, nil


### PR DESCRIPTION
I would love to get a more informative error message here. I keep seeing this happen but since the error does not contain the hash of the CAS item being fetched, it's very tricky to figure out what goes wrong from the access logs.
Specifically the error I'm seeing is this:
```
Warning: expected item to be on disk, but something happened: offset table values should increase: 0 -> 29
```
I'm hoping that with a hash to reference in the logs, I can find out what corrupts the headers