### PR TITLE
Skip a job in Bazel downstream pipeline

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -34,6 +34,7 @@ tasks:
       - "bazel run //:gazelle"
       - "bazel mod tidy"
       - "git diff --exit-code" # If there is a diff, fail.
+    skip_in_bazel_downstream_pipeline: "Lockfile could change when building with Bazel@HEAD"
   check_gofmt:
     platform: ubuntu2004
     name: "go fmt"


### PR DESCRIPTION
The lockfile could change due to lockfile format change implemented at Bazel HEAD.

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4117#0191df49-84b6-4f83-868f-d0abd7916518