### PR TITLE
prom: Add option to specify metrics prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ OPTIONS:
 
    --http_metrics_prefix Prefix HTTP metrics names with `bazel_remote`
       (default: false, ie no prefix)
-	  [$BAZEL_HTTP_METRICS_PREFIX]
+	  [$BAZEL_REMOTE_HTTP_METRICS_PREFIX]
 
    --experimental_remote_asset_api Whether to enable the experimental remote
       asset API implementation. (default: false, ie disable remote asset API)

--- a/README.md
+++ b/README.md
@@ -432,6 +432,10 @@ OPTIONS:
       endpoint. (default: false, ie disable metrics)
       [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]
 
+   --http_metrics_prefix Prefix to add to HTTP metric names
+      (default: "", ie no prefix)
+	  [$BAZEL_HTTP_METRICS_PREFIX]
+
    --experimental_remote_asset_api Whether to enable the experimental remote
       asset API implementation. (default: false, ie disable remote asset API)
       [$BAZEL_REMOTE_EXPERIMENTAL_REMOTE_ASSET_API]

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ OPTIONS:
       endpoint. (default: false, ie disable metrics)
       [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]
 
-   --http_metrics_prefix Prefix to add to HTTP metric names
-      (default: "", ie no prefix)
+   --http_metrics_prefix Prefix HTTP metrics names with `bazel_remote`
+      (default: false, ie no prefix)
 	  [$BAZEL_HTTP_METRICS_PREFIX]
 
    --experimental_remote_asset_api Whether to enable the experimental remote

--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,7 @@ type Config struct {
 	EnableACKeyInstanceMangling bool                      `yaml:"enable_ac_key_instance_mangling"`
 	EnableEndpointMetrics       bool                      `yaml:"enable_endpoint_metrics"`
 	MetricsDurationBuckets      []float64                 `yaml:"endpoint_metrics_duration_buckets"`
-	HttpMetricsPrefix           string                    `yaml:"http_metrics_prefix"`
+	HttpMetricsPrefix           bool                      `yaml:"http_metrics_prefix"`
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
@@ -176,7 +176,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 	disableGRPCACDepsCheck bool,
 	enableACKeyInstanceMangling bool,
 	enableEndpointMetrics bool,
-	httpMetricsPrefix string,
+	httpMetricsPrefix bool,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
@@ -665,7 +665,7 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Bool("disable_grpc_ac_deps_check"),
 		ctx.Bool("enable_ac_key_instance_mangling"),
 		ctx.Bool("enable_endpoint_metrics"),
-		ctx.String("http_metrics_prefix"),
+		ctx.Bool("http_metrics_prefix"),
 		ctx.Bool("experimental_remote_asset_api"),
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),

--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	EnableACKeyInstanceMangling bool                      `yaml:"enable_ac_key_instance_mangling"`
 	EnableEndpointMetrics       bool                      `yaml:"enable_endpoint_metrics"`
 	MetricsDurationBuckets      []float64                 `yaml:"endpoint_metrics_duration_buckets"`
+	HttpMetricsPrefix           string                    `yaml:"http_metrics_prefix"`
 	ExperimentalRemoteAssetAPI  bool                      `yaml:"experimental_remote_asset_api"`
 	HTTPReadTimeout             time.Duration             `yaml:"http_read_timeout"`
 	HTTPWriteTimeout            time.Duration             `yaml:"http_write_timeout"`
@@ -175,6 +176,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 	disableGRPCACDepsCheck bool,
 	enableACKeyInstanceMangling bool,
 	enableEndpointMetrics bool,
+	httpMetricsPrefix string,
 	experimentalRemoteAssetAPI bool,
 	httpReadTimeout time.Duration,
 	httpWriteTimeout time.Duration,
@@ -211,6 +213,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 		EnableACKeyInstanceMangling: enableACKeyInstanceMangling,
 		EnableEndpointMetrics:       enableEndpointMetrics,
 		MetricsDurationBuckets:      defaultDurationBuckets,
+		HttpMetricsPrefix:           httpMetricsPrefix,
 		ExperimentalRemoteAssetAPI:  experimentalRemoteAssetAPI,
 		HTTPReadTimeout:             httpReadTimeout,
 		HTTPWriteTimeout:            httpWriteTimeout,
@@ -662,6 +665,7 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Bool("disable_grpc_ac_deps_check"),
 		ctx.Bool("enable_ac_key_instance_mangling"),
 		ctx.Bool("enable_endpoint_metrics"),
+		ctx.String("http_metrics_prefix"),
 		ctx.Bool("experimental_remote_asset_api"),
 		ctx.Duration("http_read_timeout"),
 		ctx.Duration("http_write_timeout"),

--- a/main.go
+++ b/main.go
@@ -289,6 +289,7 @@ func startHttpServer(c *config.Config, httpServer **http.Server,
 
 		metricsMdlw := middleware.New(middleware.Config{
 			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{
+				Prefix: c.HttpMetricsPrefix,
 				DurationBuckets: c.MetricsDurationBuckets,
 			}),
 		})

--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ func startHttpServer(c *config.Config, httpServer **http.Server,
 
 		metricsMdlw := middleware.New(middleware.Config{
 			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{
-				Prefix: c.HttpMetricsPrefix,
+				Prefix:          c.HttpMetricsPrefix,
 				DurationBuckets: c.MetricsDurationBuckets,
 			}),
 		})

--- a/main.go
+++ b/main.go
@@ -287,9 +287,14 @@ func startHttpServer(c *config.Config, httpServer **http.Server,
 	if c.EnableEndpointMetrics {
 		log.Println("Endpoint metrics: enabled")
 
+		prefix := ""
+		if c.HttpMetricsPrefix {
+			prefix = "bazel_remote"
+		}
+
 		metricsMdlw := middleware.New(middleware.Config{
 			Recorder: httpmetrics.NewRecorder(httpmetrics.Config{
-				Prefix:          c.HttpMetricsPrefix,
+				Prefix:          prefix,
 				DurationBuckets: c.MetricsDurationBuckets,
 			}),
 		})

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -473,9 +473,9 @@ func GetCliFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "http_metrics_prefix",
-			Usage:       "Prefix to apply to exported http metrics",
+			Usage:       "Whether to prefix http metrics with `bazel_remote` or not",
 			DefaultText: "false, ie no prefix",
-			EnvVars:     []string{"BAZEL_HTTP_METRICS_PREFIX"},
+			EnvVars:     []string{"BAZEL_REMOTE_HTTP_METRICS_PREFIX"},
 		},
 		&cli.BoolFlag{
 			Name:        "experimental_remote_asset_api",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -471,10 +471,10 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "false, ie disable metrics",
 			EnvVars:     []string{"BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS"},
 		},
-		&cli.StringFlag{
+		&cli.BoolFlag{
 			Name:        "http_metrics_prefix",
 			Usage:       "Prefix to apply to exported http metrics",
-			DefaultText: "empty string, ie no prefix",
+			DefaultText: "false, ie no prefix",
 			EnvVars:     []string{"BAZEL_HTTP_METRICS_PREFIX"},
 		},
 		&cli.BoolFlag{

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -471,6 +471,12 @@ func GetCliFlags() []cli.Flag {
 			DefaultText: "false, ie disable metrics",
 			EnvVars:     []string{"BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS"},
 		},
+		&cli.StringFlag{
+			Name:        "http_metrics_prefix",
+			Usage:       "Prefix to apply to exported http metrics",
+			DefaultText: "empty string, ie no prefix",
+			EnvVars:     []string{"BAZEL_HTTP_METRICS_PREFIX"},
+		},
 		&cli.BoolFlag{
 			Name:        "experimental_remote_asset_api",
 			Usage:       "Whether to enable the experimental remote asset API implementation.",


### PR DESCRIPTION
It's useful to be able to prefix the metrics that are being reported so as to more easily differentiate them from other applications that are using the same metrics.

This change adds the necessary bits (environment var, config file, command line) to support capturing the prefix and passing it through to the httpmetrics library.