### PR TITLE
Support session tokens for s3 proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ OPTIONS:
       using S3 proxy backend. Applies to s3 auth method(s): access_key.
       [$BAZEL_REMOTE_S3_SECRET_ACCESS_KEY]
 
+   --s3.session_token value The S3/minio session token to use when using S3
+      proxy backend. Optional. Applies to s3 auth method(s): access_key.
+      [$BAZEL_REMOTE_S3_SESSION_TOKEN, $AWS_SESSION_TOKEN]
+
    --s3.signature_type value Which type of s3 signature to use when using S3
       proxy backend. Only applies when using the s3 access_key auth method.
       Allowed values: v2, v4, v4streaming, anonymous. (default: v4)
@@ -556,6 +560,7 @@ http_address: 0.0.0.0:8080
 #  auth_method: access_key
 #  access_key_id: EXAMPLE_ACCESS_KEY
 #  secret_access_key: EXAMPLE_SECRET_KEY
+#  session_token: EXAMPLE_SESSION_TOKEN
 #  signature_type: v4
 #
 # IAM Role authentication.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ OPTIONS:
 
    --s3.session_token value The S3/minio session token to use when using S3
       proxy backend. Optional. Applies to s3 auth method(s): access_key.
-      [$BAZEL_REMOTE_S3_SESSION_TOKEN, $AWS_SESSION_TOKEN]
+      [$BAZEL_REMOTE_S3_SESSION_TOKEN]
 
    --s3.signature_type value Which type of s3 signature to use when using S3
       proxy backend. Only applies when using the s3 access_key auth method.

--- a/config/config.go
+++ b/config/config.go
@@ -561,6 +561,7 @@ func get(ctx *cli.Context) (*Config, error) {
 			AuthMethod:               ctx.String("s3.auth_method"),
 			AccessKeyID:              ctx.String("s3.access_key_id"),
 			SecretAccessKey:          ctx.String("s3.secret_access_key"),
+			SessionToken:             ctx.String("s3.session_token"),
 			SignatureType:            ctx.String("s3.signature_type"),
 			DisableSSL:               ctx.Bool("s3.disable_ssl"),
 			UpdateTimestamps:         ctx.Bool("s3.update_timestamps"),

--- a/config/s3.go
+++ b/config/s3.go
@@ -17,6 +17,7 @@ type S3CloudStorageConfig struct {
 	AuthMethod               string `yaml:"auth_method"`
 	AccessKeyID              string `yaml:"access_key_id"`
 	SecretAccessKey          string `yaml:"secret_access_key"`
+	SessionToken             string `yaml:"session_token"`
 	SignatureType            string `yaml:"signature_type"`
 	DisableSSL               bool   `yaml:"disable_ssl"`
 	UpdateTimestamps         bool   `yaml:"update_timestamps"`
@@ -42,7 +43,7 @@ func (s3c S3CloudStorageConfig) GetCredentials() (*credentials.Credentials, erro
 		log.Println("S3 Credentials: using access/secret access key.")
 		signatureType := parseSignatureType(s3c.SignatureType)
 		log.Printf("S3 Sign: using %s sign\n", signatureType.String())
-		return credentials.NewStatic(s3c.AccessKeyID, s3c.SecretAccessKey, "", signatureType), nil
+		return credentials.NewStatic(s3c.AccessKeyID, s3c.SecretAccessKey, s3c.SessionToken, signatureType), nil
 	} else if s3c.AuthMethod == s3proxy.AuthMethodIAMRole {
 		// Fall back to getting credentials from IAM
 		log.Println("S3 Credentials: using IAM.")

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -342,7 +342,7 @@ func GetCliFlags() []cli.Flag {
 			Name:    "s3.session_token",
 			Value:   "",
 			Usage:   "The S3/minio session token to use when using S3 proxy backend. Optional. " + s3AuthMsg(s3proxy.AuthMethodAccessKey),
-			EnvVars: []string{"BAZEL_REMOTE_S3_SESSION_TOKEN", "AWS_SESSION_TOKEN"},
+			EnvVars: []string{"BAZEL_REMOTE_S3_SESSION_TOKEN"},
 		},
 		&cli.StringFlag{
 			Name:        "s3.signature_type",

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -339,6 +339,12 @@ func GetCliFlags() []cli.Flag {
 			EnvVars: []string{"BAZEL_REMOTE_S3_SECRET_ACCESS_KEY"},
 		},
 		&cli.StringFlag{
+			Name:    "s3.session_token",
+			Value:   "",
+			Usage:   "The S3/minio session token to use when using S3 proxy backend. Optional. " + s3AuthMsg(s3proxy.AuthMethodAccessKey),
+			EnvVars: []string{"BAZEL_REMOTE_S3_SESSION_TOKEN", "AWS_SESSION_TOKEN"},
+		},
+		&cli.StringFlag{
 			Name:        "s3.signature_type",
 			Usage:       "Which type of s3 signature to use when using S3 proxy backend. Only applies when using the s3 access_key auth method. Allowed values: v2, v4, v4streaming, anonymous.",
 			DefaultText: "v4",


### PR DESCRIPTION
This adds a new arg `--s3.session_token`, to support passing through an AWS session token along with an access key, when using `--s3.auth_method=access_key`. This allows using temporary credentials (as returned by assuming a role) for short-lived invocations of bazel-remote.

Some additional background: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

Fixes #634 