### PR TITLE
Only show supported zstd implementations in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ OPTIONS:
    --storage_mode value Which format to store CAS blobs in. Must be one of
       "zstd" or "uncompressed". (default: "zstd") [$BAZEL_REMOTE_STORAGE_MODE]
 
-   --zstd_implementation value ZSTD implementation to use. Must be one of
-      "go" or "cgo". (default: "go") [$BAZEL_REMOTE_ZSTD_IMPLEMENTATION]
+   --zstd_implementation value ZSTD implementation to use. Supported values:
+      "cgo", "go" (default: "go") [$BAZEL_REMOTE_ZSTD_IMPLEMENTATION]
 
    --http_address value Address specification for the HTTP server listener,
       formatted either as [host]:port for TCP or unix://path.sock for Unix

--- a/cache/disk/zstdimpl/zstdimpl.go
+++ b/cache/disk/zstdimpl/zstdimpl.go
@@ -3,6 +3,7 @@ package zstdimpl
 import (
 	"fmt"
 	"io"
+	"slices"
 )
 
 var registry map[string]ZstdImpl
@@ -17,9 +18,21 @@ func register(implName string, impl ZstdImpl) {
 func Get(implName string) (ZstdImpl, error) {
 	impl, ok := registry[implName]
 	if !ok {
-		return nil, fmt.Errorf("Unrecognized ZSTD implementation: %s, supported: %s", implName, registry)
+		return nil, fmt.Errorf("Unrecognized ZSTD implementation: %s, supported: %s", implName, GetImplementations())
 	}
 	return impl, nil
+}
+
+func GetImplementations() []string {
+	result := make([]string, 0, len(registry))
+
+	for name := range registry {
+		result = append(result, name)
+	}
+
+	slices.Sort(result)
+
+	return result
 }
 
 type ZstdImpl interface {

--- a/utils/flags/BUILD.bazel
+++ b/utils/flags/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cache/azblobproxy:go_default_library",
+        "//cache/disk/zstdimpl:go_default_library",
         "//cache/s3proxy:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/buchgr/bazel-remote/v2/cache/azblobproxy"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
 	"github.com/buchgr/bazel-remote/v2/cache/s3proxy"
 
 	"github.com/urfave/cli/v2"
@@ -18,6 +19,15 @@ func s3AuthMsg(authMethods ...string) string {
 
 func azBlobAuthMsg(authMethods ...string) string {
 	return fmt.Sprintf("Applies to AzBlob auth method(s): %s.", strings.Join(authMethods, ", "))
+}
+
+func getSupportedZstdImplsString() string {
+	impls := zstdimpl.GetImplementations()
+	for i, name := range impls {
+		impls[i] = "\"" + name + "\""
+	}
+
+	return strings.Join(impls, ", ")
 }
 
 // GetCliFlags returns a slice of cli.Flag's that bazel-remote accepts.
@@ -50,7 +60,7 @@ func GetCliFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "zstd_implementation",
 			Value:   "go",
-			Usage:   "ZSTD implementation to use. Must be one of \"go\" or \"cgo\".",
+			Usage:   "ZSTD implementation to use. Supported values: " + getSupportedZstdImplsString(),
 			EnvVars: []string{"BAZEL_REMOTE_ZSTD_IMPLEMENTATION"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
And while we're at it, improve the error message that is shown when an unsupported zstd implementation is specified.