### PR TITLE
Fix --http_metrics_prefix help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,9 +436,8 @@ OPTIONS:
       endpoint. (default: false, ie disable metrics)
       [$BAZEL_REMOTE_ENABLE_ENDPOINT_METRICS]
 
-   --http_metrics_prefix Prefix HTTP metrics names with `bazel_remote`
-      (default: false, ie no prefix)
-	  [$BAZEL_REMOTE_HTTP_METRICS_PREFIX]
+   --http_metrics_prefix Whether to prefix http metrics with "bazel_remote"
+      or not (default: false, ie no prefix) [$BAZEL_REMOTE_HTTP_METRICS_PREFIX]
 
    --experimental_remote_asset_api Whether to enable the experimental remote
       asset API implementation. (default: false, ie disable remote asset API)

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -489,7 +489,7 @@ func GetCliFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:        "http_metrics_prefix",
-			Usage:       "Whether to prefix http metrics with `bazel_remote` or not",
+			Usage:       "Whether to prefix http metrics with \"bazel_remote\" or not",
 			DefaultText: "false, ie no prefix",
 			EnvVars:     []string{"BAZEL_REMOTE_HTTP_METRICS_PREFIX"},
 		},


### PR DESCRIPTION
urfave/cli interprets backticks as referring to a placeholder variable, but this is a boolean flag with no option/variable.