### PR TITLE
Fix validating hash on uncompressed storage

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -355,7 +355,7 @@ func (c *diskCache) writeAndCloseFile(ctx context.Context, r io.Reader, kind cac
 	if kind == cache.CAS {
 		sizeOnDisk, err = casblob.WriteAndClose(c.zstd, r, f, c.storageMode, hash, size)
 		if err != nil {
-			return -1, annotate.Err(ctx, "Failed to write compressed CAS blob to disk", err)
+			return -1, annotate.Err(ctx, "Failed to write CAS blob to disk", err)
 		}
 		closeFile = false
 		return sizeOnDisk, nil

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -352,7 +352,7 @@ func (c *diskCache) writeAndCloseFile(ctx context.Context, r io.Reader, kind cac
 	var err error
 	var sizeOnDisk int64
 
-	if kind == cache.CAS && c.storageMode != casblob.Identity {
+	if kind == cache.CAS {
 		sizeOnDisk, err = casblob.WriteAndClose(c.zstd, r, f, c.storageMode, hash, size)
 		if err != nil {
 			return -1, annotate.Err(ctx, "Failed to write compressed CAS blob to disk", err)


### PR DESCRIPTION
When storage mode is `uncompressed`, cas blobs are not validated against their sha and accepted regardless. The validation is instead performed when using `zstd` storage mode. This refactors `casbob.WriteAndClose` to write both compressed and uncompress blobs and validate their content.