### PR TITLE
Add more human-readable GitTags item to the status page

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # Include git version info
 build --stamp
-build --workspace_status_command 'echo STABLE_GIT_COMMIT $(git rev-parse HEAD)'
+build --workspace_status_command=$(pwd)/git-commit.sh
 
 common --enable_bzlmod

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -42,7 +42,10 @@ go_binary(
     pure = "off",
     static = "off",
     visibility = ["//visibility:public"],
-    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "main.gitCommit": "{STABLE_GIT_COMMIT}",
+        "main.gitTags": "{GIT_TAGS}",
+    },
 )
 
 go_binary(
@@ -54,7 +57,10 @@ go_binary(
     pure = "off",
     static = "off",
     visibility = ["//visibility:public"],
-    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "main.gitCommit": "{STABLE_GIT_COMMIT}",
+        "main.gitTags": "{GIT_TAGS}",
+    },
 )
 
 go_binary(
@@ -66,7 +72,10 @@ go_binary(
     pure = "off",
     static = "on",
     visibility = ["//visibility:public"],
-    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "main.gitCommit": "{STABLE_GIT_COMMIT}",
+        "main.gitTags": "{GIT_TAGS}",
+    },
 )
 
 go_binary(
@@ -78,7 +87,10 @@ go_binary(
     pure = "off",
     #static = "on", # With static enabled, I get the following error: "ld: library not found for -lcrt0.o"
     visibility = ["//visibility:public"],
-    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "main.gitCommit": "{STABLE_GIT_COMMIT}",
+        "main.gitTags": "{GIT_TAGS}",
+    },
 )
 
 go_binary(
@@ -90,7 +102,10 @@ go_binary(
     pure = "off",
     #static = "on", # With static enabled, I get the following error: "ld: library not found for -lcrt0.o"
     visibility = ["//visibility:public"],
-    x_defs = {"main.gitCommit": "{STABLE_GIT_COMMIT}"},
+    x_defs = {
+        "main.gitCommit": "{STABLE_GIT_COMMIT}",
+        "main.gitTags": "{GIT_TAGS}",
+    },
 )
 
 # The distroless static container image's nonroot user id.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ $ curl http://localhost:8080/status
  "ReservedSize": 876400,
  "MaxSize": 8589934592000,
  "NumFiles": 621413,
- "ServerTime": 1588329927,
- "GitCommit": "940d540d3a7f17939c3df0038530122eabef2f19",
+ "ServerTime": 1746258977,
+ "GitCommit": "d0f166cdd973342ec4aa8a51228cfd3a7a205414",
+ "GitTags": "v2.5.1",
  "NumGoroutines": 12
 }
 ```

--- a/darwin-build.sh
+++ b/darwin-build.sh
@@ -4,7 +4,10 @@ set -euxo pipefail
 
 GOARCH=${GOARCH:-arm64}
 
-VERSION_TAG="$(git rev-parse HEAD)"
-VERSION_LINK_FLAG="main.gitCommit=${VERSION_TAG}"
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_TAGS=$(git tag --points-at HEAD | sort -h | paste -sd "," -)
 
-CGO_ENABLED=1 GOOS=darwin GOARCH=$GOARCH go build -a -ldflags "--X ${VERSION_LINK_FLAG}" .
+GIT_COMMIT_LINK_FLAG="main.gitCommit=${GIT_COMMIT}"
+GIT_TAGS_LINK_FLAG="main.gitTags=${GIT_TAGS}"
+
+CGO_ENABLED=1 GOOS=darwin GOARCH=$GOARCH go build -a -ldflags "-X \"${GIT_COMMIT_LINK_FLAG}\" -X \"${GIT_TAGS_LINK_FLAG}\"" .

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -1,2 +1,7 @@
-#!/bin/sh
-echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
+#!/bin/bash
+set -eu
+
+echo "STABLE_GIT_COMMIT $(git rev-parse HEAD)"
+
+git_tag_info=$(git tag --points-at HEAD | sort -h | paste -sd "," -)
+echo "GIT_TAGS $git_tag_info"

--- a/linux-build.sh
+++ b/linux-build.sh
@@ -4,7 +4,10 @@ set -euxo pipefail
 
 GOARCH=${GOARCH:-amd64}
 
-VERSION_TAG="$(git rev-parse HEAD)"
-VERSION_LINK_FLAG="main.gitCommit=${VERSION_TAG}"
+GIT_COMMIT=$(git rev-parse HEAD)
+GIT_TAGS=$(git tag --points-at HEAD | sort -h | paste -sd "," -)
 
-CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH go build -a -ldflags "-X ${VERSION_LINK_FLAG}" .
+GIT_COMMIT_LINK_FLAG="main.gitCommit=${GIT_COMMIT}"
+GIT_TAGS_LINK_FLAG="main.gitTags=${GIT_TAGS}"
+
+CGO_ENABLED=1 GOOS=linux GOARCH=$GOARCH go build -a -ldflags "-X \"${GIT_COMMIT_LINK_FLAG}\" -X \"${GIT_TAGS_LINK_FLAG}\"" .

--- a/main.go
+++ b/main.go
@@ -42,6 +42,10 @@ import (
 // is set through linker options.
 var gitCommit string
 
+// gitTags is another version stamp, with the set of tags for the current
+// commit joined by commas.
+var gitTags string
+
 func main() {
 	app := cli.NewApp()
 
@@ -83,8 +87,12 @@ func run(ctx *cli.Context) error {
 	if len(gitCommit) > 0 && gitCommit != "{STABLE_GIT_COMMIT}" {
 		maybeGitCommitMsg = fmt.Sprintf(" from git commit %s", gitCommit)
 	}
-	log.Printf("bazel-remote built with %s%s.",
-		runtime.Version(), maybeGitCommitMsg)
+	maybeGitTagsMsg := ""
+	if len(gitTags) > 0 && gitTags != "{GIT_TAGS}" {
+		maybeGitTagsMsg = " " + gitTags
+	}
+	log.Printf("bazel-remote built with %s%s%s.",
+		runtime.Version(), maybeGitCommitMsg, maybeGitTagsMsg)
 
 	rlimit.Raise()
 
@@ -240,7 +248,7 @@ func startHttpServer(c *config.Config, httpServer **http.Server,
 	checkClientCertForWrites := c.TLSCaFile != ""
 	validateAC := !c.DisableHTTPACValidation
 	h := server.NewHTTPCache(diskCache, c.AccessLogger, c.ErrorLogger, validateAC,
-		c.EnableACKeyInstanceMangling, checkClientCertForReads, checkClientCertForWrites, gitCommit)
+		c.EnableACKeyInstanceMangling, checkClientCertForReads, checkClientCertForWrites, gitCommit, gitTags)
 
 	cacheHandler := h.CacheHandler
 	var ldapAuthenticator authenticator

--- a/server/http.go
+++ b/server/http.go
@@ -45,6 +45,7 @@ type httpCache struct {
 	validateAC               bool
 	mangleACKeys             bool
 	gitCommit                string
+	gitTags                  string
 	checkClientCertForReads  bool
 	checkClientCertForWrites bool
 }
@@ -57,6 +58,7 @@ type statusPageData struct {
 	NumFiles         int
 	ServerTime       int64
 	GitCommit        string
+	GitTags          string
 	NumGoroutines    int
 }
 
@@ -64,7 +66,7 @@ type statusPageData struct {
 // accessLogger will print one line for each HTTP request to stdout.
 // errorLogger will print unexpected server errors. Inexistent files and malformed URLs will not
 // be reported.
-func NewHTTPCache(cache disk.Cache, accessLogger cache.Logger, errorLogger cache.Logger, validateAC bool, mangleACKeys bool, checkClientCertForReads bool, checkClientCertForWrites bool, commit string) HTTPCache {
+func NewHTTPCache(cache disk.Cache, accessLogger cache.Logger, errorLogger cache.Logger, validateAC bool, mangleACKeys bool, checkClientCertForReads bool, checkClientCertForWrites bool, commit string, gitTags string) HTTPCache {
 
 	_, _, numItems, _ := cache.Stats()
 
@@ -82,6 +84,10 @@ func NewHTTPCache(cache disk.Cache, accessLogger cache.Logger, errorLogger cache
 
 	if commit != "{STABLE_GIT_COMMIT}" {
 		hc.gitCommit = commit
+	}
+
+	if gitTags != "{GIT_TAGS}" {
+		hc.gitTags = gitTags
 	}
 
 	return hc
@@ -510,6 +516,7 @@ func (h *httpCache) StatusPageHandler(w http.ResponseWriter, r *http.Request) {
 		NumFiles:         numItems,
 		ServerTime:       time.Now().Unix(),
 		GitCommit:        h.gitCommit,
+		GitTags:          h.gitTags,
 		NumGoroutines:    goroutines,
 	})
 	if err != nil {

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -38,7 +38,7 @@ func TestDownloadFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
@@ -106,7 +106,7 @@ func TestUploadFilesConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -170,7 +170,7 @@ func TestUploadSameFileConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 	handler := http.HandlerFunc(h.CacheHandler)
 
 	var wg sync.WaitGroup
@@ -211,7 +211,7 @@ func TestUploadCorruptedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -255,7 +255,7 @@ func TestUploadEmptyActionResult(t *testing.T) {
 	mangle := false
 	checkClientCertForReads := false
 	checkClientCertForWrites := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "", "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -317,7 +317,7 @@ func testEmptyBlobAvailable(t *testing.T, method string) {
 	mangle := false
 	checkClientCertForReads := false
 	checkClientCertForWrites := false
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), validate, mangle, checkClientCertForReads, checkClientCertForWrites, "", "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.CacheHandler)
 	handler.ServeHTTP(rr, r)
@@ -340,7 +340,7 @@ func TestStatusPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(c, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(h.StatusPageHandler)
 	handler.ServeHTTP(rr, r)
@@ -484,7 +484,7 @@ func TestRemoteReturnsNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "")
+	h := NewHTTPCache(emptyCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), true, false, false, false, "", "")
 	// create a fake http.Request
 	_, hash := testutils.RandomDataAndHash(1024)
 	url, _ := url.Parse(fmt.Sprintf("http://localhost:8080/ac/%s", hash))
@@ -522,7 +522,7 @@ func TestManglingACKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewHTTPCache(diskCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), false, true, false, false, "")
+	h := NewHTTPCache(diskCache, testutils.NewSilentLogger(), testutils.NewSilentLogger(), false, true, false, false, "", "")
 	// create a fake http.Request
 	data, hash := testutils.RandomDataAndHash(blobSize)
 	err = diskCache.Put(context.Background(), cache.RAW, hash, int64(len(data)), bytes.NewReader(data))


### PR DESCRIPTION
bazel-remote has included a GitCommit field in the /status page for some time, the git ref SHA1 value is not the most readable. By adding a new GitTags field with the comma-separated list of tags (if any) for the current commit, it is easier to see which version of bazel-remote is running.

Relates to #436.