### PR TITLE
Fix validating hash on uncompressed storage (v2)

### DIFF
--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//cache/disk/zstdimpl:go_default_library",
         "//genproto/build/bazel/remote/execution/v2:go_default_library",
         "//utils/annotate:go_default_library",
+        "//utils/sha256verifier:go_default_library",
         "//utils/tempfile:go_default_library",
         "//utils/validate:go_default_library",
         "@com_github_djherbis_atime//:go_default_library",

--- a/utils/sha256verifier/BUILD.bazel
+++ b/utils/sha256verifier/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sha256verifier.go"],
+    importpath = "github.com/buchgr/bazel-remote/v2/utils/sha256verifier",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sha256verifier_test.go"],
+    embed = [":go_default_library"],
+)

--- a/utils/sha256verifier/sha256verifier.go
+++ b/utils/sha256verifier/sha256verifier.go
@@ -1,0 +1,58 @@
+package sha256verifier
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+)
+
+type sha256verifier struct {
+	hash.Hash
+	expectedSize        int64
+	expectedHash        string
+	actualSize          int64
+	multiWriter         io.Writer
+	originalWriteCloser io.WriteCloser
+}
+
+func New(expectedHash string, expectedSize int64, writeCloser io.WriteCloser) *sha256verifier {
+	hash := sha256.New()
+
+	return &sha256verifier{
+		Hash:                hash,
+		expectedHash:        expectedHash,
+		expectedSize:        expectedSize,
+		multiWriter:         io.MultiWriter(hash, writeCloser),
+		originalWriteCloser: writeCloser,
+	}
+}
+
+func (s *sha256verifier) Write(p []byte) (int, error) {
+
+	n, err := s.multiWriter.Write(p)
+	if n > 0 {
+		s.actualSize += int64(n)
+	}
+
+	return n, err
+}
+
+func (s *sha256verifier) Close() error {
+	if s.actualSize != s.expectedSize {
+		return fmt.Errorf("Error: expected %d bytes, got %d", s.expectedSize, s.actualSize)
+	}
+
+	actualHash := hex.EncodeToString(s.Sum(nil))
+	if actualHash != s.expectedHash {
+		return fmt.Errorf("Error: expected hash %s, got %s", s.expectedHash, actualHash)
+	}
+
+	err := s.originalWriteCloser.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/utils/sha256verifier/sha256verifier_test.go
+++ b/utils/sha256verifier/sha256verifier_test.go
@@ -1,0 +1,65 @@
+package sha256verifier
+
+import (
+	"bytes"
+	"testing"
+)
+
+type bufferWithFakeCloser struct {
+	bytes.Buffer
+}
+
+func (b *bufferWithFakeCloser) Close() error {
+	return nil
+}
+
+func TestHashVerification(t *testing.T) {
+
+	var hashVerificationTests = []struct {
+		expectedSize int64
+		expectedHash string
+		data         []byte
+		success      bool
+	}{
+		{int64(0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", []byte{}, true},
+		{int64(0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", []byte{0}, false},
+		{int64(0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85", []byte{}, false},
+		{int64(4), "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a", []byte{1, 2, 3, 4}, true},
+		{int64(3), "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a", []byte{1, 2, 3, 4}, false},
+		{int64(4), "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a", []byte{1, 2, 3, 4, 0}, false},
+	}
+
+	for _, tt := range hashVerificationTests {
+
+		var buf bufferWithFakeCloser
+
+		h := New(tt.expectedHash, tt.expectedSize, &buf)
+		if h == nil {
+			t.Fatal("Expected non-nil sha256verifier")
+		}
+
+		n, err := h.Write(tt.data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != len(tt.data) {
+			t.Fatalf("Error: incomplete Write: %d, expected: %d", n, len(tt.data))
+		}
+
+		err = h.Close()
+		if tt.success {
+			if err != nil {
+				t.Fatal("Error: ", err, "expected hash", tt.expectedSize, tt.expectedHash)
+			}
+
+			if !bytes.Equal(tt.data, buf.Bytes()) {
+				t.Fatal("Error: mismatched data written")
+			}
+
+		} else {
+			if err == nil {
+				t.Fatal("Expected failure for", tt.data)
+			}
+		}
+	}
+}


### PR DESCRIPTION
When storage mode is `uncompressed`, CAS blobs are not validated and accepted regardless. The validation is currently only performed when using `zstd` storage mode.

This is an alternative fix to #819.