### PR TITLE
Optimize file removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,18 @@ OPTIONS:
 dir: path/to/cache-dir
 max_size: 100
 
+# If specified, write requests will be rejected when max_size_hard_limit is
+# reached. Clients can then decide which requests to retry. This setting can
+# be used to avoid running out of disk space when new blobs are uploaded faster
+# than old blobs can be evicted. A reasonable value might be 5% larger than
+# max_size. A higher limit might be needed when using a proxy backend.
+#
+# The max_size_hard_limit can be tuned by watching how the prometheus query
+# max_over_time(bazel_remote_disk_cache_size_bytes[$__interval]) varies
+# between bazel_remote_disk_cache_size_bytes_limit{type="evict"} and
+# bazel_remote_disk_cache_size_bytes_limit{type="reject"}.
+#max_size_hard_limit: 105
+
 # The form to store CAS blobs in ("zstd" or "uncompressed"):
 #storage_mode: zstd
 

--- a/cache/disk/load.go
+++ b/cache/disk/load.go
@@ -72,7 +72,11 @@ func New(dir string, maxSizeBytes int64, opts ...Option) (Cache, error) {
 		maxBlobSize:      math.MaxInt64,
 		maxProxyBlobSize: math.MaxInt64,
 
-		fileRemovalSem: semaphore.NewWeighted(semaphoreWeight),
+		// Acquire 1 of these before starting filesystem writes/deletes, or
+		// reject filesystem writes upon failure (since this will create a
+		// new OS thread and we don't want to hit Go's default 10,000 OS
+		// thread limit.
+		diskWaitSem: semaphore.NewWeighted(semaphoreWeight),
 
 		gaugeCacheAge: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "bazel_remote_disk_cache_longest_item_idle_time_seconds",

--- a/cache/disk/lru.go
+++ b/cache/disk/lru.go
@@ -4,7 +4,10 @@ import (
 	"container/list"
 	"errors"
 	"fmt"
+	"net/http"
+	"sync/atomic"
 
+	"github.com/buchgr/bazel-remote/v2/cache"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -42,13 +45,54 @@ type SizedLRU struct {
 	// cache below maxSize.
 	maxSize int64
 
+	// Channel containing evicted entries removed from ll, but not yet
+	// removed from the file system.
+	//
+	// The entries are wrapped in a slice to allow the queue to grow
+	// dynamically and not being limited by the channel's max size. Note
+	// that one single new large file can result in evicting thousands of
+	// small old files. And on high load, with many new files, the queue
+	// of evicting entries can grow very quickly.
+	//
+	// The channel will have capacity 1, so it can hold at most one slice
+	// of entry pointers at a time.
+	//
+	// The consumer of the channel does not need to acquire the diskCache.mu
+	// mutex.
+	//
+	// The removal of evicted files asynchronously improves the latency for
+	// Put requests, by allowing them to start writing the file earlier.
+	// This also improves latency for other requests by not having to hold
+	// the diskCache.mu mutex during file system remove syscalls.
+	queuedEvictionsChan chan []*entry
+
 	onEvict EvictCallback
 
-	gaugeCacheSizeBytes     prometheus.Gauge
-	gaugeCacheLogicalBytes  prometheus.Gauge
-	counterEvictedBytes     prometheus.Counter
-	counterOverwrittenBytes prometheus.Counter
-	summaryCacheItemBytes   prometheus.Summary
+	gaugeCacheSizeBytes      prometheus.Gauge
+	gaugeCacheSizeBytesLimit *prometheus.GaugeVec
+	gaugeCacheLogicalBytes   prometheus.Gauge
+	counterEvictedBytes      prometheus.Counter
+	counterOverwrittenBytes  prometheus.Counter
+
+	summaryCacheItemBytes prometheus.Summary
+
+	// Peak value of: currentSize + currentlyEvictingSize
+	// Type is uint64 instead of int64 in order to allow representing also
+	// large, rejected reservations that would have resulted in values above
+	// the int64 maxSizeHardLimit.
+	totalDiskSizePeak uint64
+
+	// Configured max allowed bytes on disk for the cache, including files
+	// queued for eviction but not yet removed. Value <= 0 means no
+	// limit. The maxSizeHardLimit is expected to be configured higher than
+	// maxSize (e.g., 5% higher) to allow the asynchronous removal to catch
+	// up after peaks of file writes.
+	maxSizeHardLimit int64
+
+	// Number of bytes currently being evicted (removed from lru but not
+	// yet removed from disk). Is allowed to be accessed and changed
+	// without holding the diskCache.mu lock.
+	queuedEvictionsSize atomic.Int64
 }
 
 type entry struct {
@@ -70,8 +114,15 @@ func NewSizedLRU(maxSize int64, onEvict EvictCallback, initialCapacity int) Size
 
 		gaugeCacheSizeBytes: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "bazel_remote_disk_cache_size_bytes",
-			Help: "The current number of bytes in the disk backend",
+			Help: "The peak number of bytes in the disk backend for the previous 30 second period.",
 		}),
+		gaugeCacheSizeBytesLimit: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "bazel_remote_disk_cache_size_bytes_limit",
+				Help: "The currently configured limits of different types, e.g. for when disk cache evicts data or rejects requests.",
+			},
+			[]string{"type"},
+		),
 		gaugeCacheLogicalBytes: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "bazel_remote_disk_cache_logical_bytes",
 			Help: "The current number of bytes in the disk backend if they were uncompressed",
@@ -94,15 +145,26 @@ func NewSizedLRU(maxSize int64, onEvict EvictCallback, initialCapacity int) Size
 				1:    0,
 			},
 		}),
+		queuedEvictionsChan: make(chan []*entry, 1),
 	}
 }
 
 func (c *SizedLRU) RegisterMetrics() {
 	prometheus.MustRegister(c.gaugeCacheSizeBytes)
+	prometheus.MustRegister(c.gaugeCacheSizeBytesLimit)
 	prometheus.MustRegister(c.gaugeCacheLogicalBytes)
 	prometheus.MustRegister(c.counterEvictedBytes)
 	prometheus.MustRegister(c.counterOverwrittenBytes)
 	prometheus.MustRegister(c.summaryCacheItemBytes)
+
+	// Set gauges to constant configured values to help visualize configured limits
+	// and in particular help tuning max_size_hard_limit configuration by comparing it
+	// against peak values of the bazel_remote_disk_cache_size_bytes prometheus gauge
+	// and give awareness about if getting close to rejecting requests.
+	c.gaugeCacheSizeBytesLimit.WithLabelValues("evict").Set(float64(c.maxSize))
+	if c.maxSizeHardLimit > 0 {
+		c.gaugeCacheSizeBytesLimit.WithLabelValues("reject").Set(float64(c.maxSizeHardLimit))
+	}
 }
 
 // Add adds a (key, value) to the cache, evicting items as necessary.
@@ -121,6 +183,16 @@ func (c *SizedLRU) Add(key Key, value lruItem) (ok bool) {
 		return false
 	}
 
+	// The files are already stored on disk when Add is invoked, therefore
+	// it is not motivated to reject based on maxSizeHardLimit. The check
+	// against maxSize is considered sufficient. However, invoke
+	// calcTotalDiskSizeAndUpdatePeak to update the peak value. The peak
+	// value is updated BEFORE triggering new evictions, to make the
+	// metrics reflect that both the new file and the files it
+	// evicts/replaces exists at disk at same time for a short period of
+	// time (unless Reserve method was used and evicted them).
+	c.calcTotalDiskSizeAndUpdatePeak(roundedUpSizeOnDisk)
+
 	var sizeDelta, uncompressedSizeDelta int64
 	if ee, ok := c.cache[key]; ok {
 		sizeDelta = roundedUpSizeOnDisk - roundUp4k(ee.Value.(*entry).value.sizeOnDisk)
@@ -131,10 +203,9 @@ func (c *SizedLRU) Add(key Key, value lruItem) (ok bool) {
 		c.ll.MoveToFront(ee)
 		c.counterOverwrittenBytes.Add(float64(ee.Value.(*entry).value.sizeOnDisk))
 
-		prevValue := ee.Value.(*entry).value
-		if c.onEvict != nil {
-			c.onEvict(key, prevValue)
-		}
+		kv := ee.Value.(*entry)
+		kvCopy := &entry{kv.key, kv.value}
+		c.appendEvictionToQueue(kvCopy)
 
 		ee.Value.(*entry).value = value
 	} else {
@@ -159,7 +230,6 @@ func (c *SizedLRU) Add(key Key, value lruItem) (ok bool) {
 	c.currentSize += sizeDelta
 	c.uncompressedSize += uncompressedSizeDelta
 
-	c.gaugeCacheSizeBytes.Set(float64(c.currentSize))
 	c.gaugeCacheLogicalBytes.Set(float64(c.uncompressedSize))
 	c.summaryCacheItemBytes.Observe(float64(sizeDelta))
 
@@ -180,7 +250,6 @@ func (c *SizedLRU) Get(key Key) (value lruItem, ok bool) {
 func (c *SizedLRU) Remove(key Key) {
 	if ele, hit := c.cache[key]; hit {
 		c.removeElement(ele)
-		c.gaugeCacheSizeBytes.Set(float64(c.currentSize))
 		c.gaugeCacheLogicalBytes.Set(float64(c.uncompressedSize))
 	}
 }
@@ -223,24 +292,68 @@ func sumLargerThan(a, b, c int64) bool {
 
 var errReservation = errors.New("internal reservation error")
 
-func (c *SizedLRU) Reserve(size int64) (bool, error) {
+func (c *SizedLRU) Reserve(size int64) error {
 	if size == 0 {
-		return true, nil
+		return nil
 	}
 
 	if size < 0 {
-		return false, fmt.Errorf("Invalid negative blob size: %d", size)
+		return &cache.Error{
+			Code: http.StatusBadRequest,
+			Text: fmt.Sprintf("Invalid negative blob size: %d", size),
+		}
 	}
 
 	if size > c.maxSize {
-		return false, fmt.Errorf("Unable to reserve space for blob (size: %d) larger than cache size %d", size, c.maxSize)
+		// Classified as http.StatusBadRequest because the current
+		// configuration does not support it, and retrying will not
+		// resolve the issue.
+		return &cache.Error{
+			Code: http.StatusBadRequest,
+			Text: fmt.Sprintf("Unable to reserve space for blob (size: %d) larger than cache size %d", size, c.maxSize),
+		}
 	}
 
 	if sumLargerThan(size, c.reservedSize, c.maxSize) {
 		// If size + c.reservedSize is larger than c.maxSize
 		// then we cannot evict enough items to make enough
-		// space.
-		return false, fmt.Errorf("INTERNAL ERROR: unable to reserve enough space for blob with size %d (undersized cache?)", size)
+		// space. Classified as http.StatusInsufficientStorage because
+		// retrying may resolve the issue.
+		return &cache.Error{
+			Code: http.StatusInsufficientStorage,
+			Text: fmt.Sprintf("The item (%d) + reserved space (%d) is larger than the cache's maximum size (%d).", size, c.reservedSize, c.maxSize),
+		}
+	}
+
+	// Note that the calculated value and the potentially updated peak
+	// value, includes the value tried to be reserved. In other words,
+	// the peak value is updated even if the limit is exceeded, and the
+	// reservation rejected. That is on purpose to allow using the
+	// prometheus gague of the peak value to understand why reservations
+	// are rejected. That gauge is an aid for tuning disk size limit,
+	// and it is therefore beneficial that the same calculated
+	// value (returned as totalDiskSizeNow) is used both for the metrics
+	// gauge and the logic for deciding about rejection.
+	totalDiskSizeNow := c.calcTotalDiskSizeAndUpdatePeak(size)
+
+	if c.maxSizeHardLimit > 0 && totalDiskSizeNow > (uint64(c.maxSizeHardLimit)) {
+
+		// Reject and let the client decide about retries. E.g., a bazel
+		// client either building locally or with
+		// --remote_local_fallback, can choose to have minimal number
+		// of retries since uploading the build result is not
+		// critical. And a client depending on remote execution
+		// where upload is critical can choose a large number of
+		// retries. Retrying only critical writes increases the chance
+		// for bazel-remote to recover from the overload more quickly.
+		// Note that bazel-remote can continue serving reads even when
+		// overloaded by writes, e.g., when SSD's write IOPS capacity
+		// is overloaded but reads can be served from operating
+		// system's file system cache in RAM.
+		return &cache.Error{
+			Code: http.StatusInsufficientStorage,
+			Text: fmt.Sprintf("Out of disk space, due to too large or too many concurrent cache requests. Needed %d but limit is %d bytes. Please try again later.", totalDiskSizeNow, c.maxSizeHardLimit),
+		}
 	}
 
 	// Evict elements until we are able to reserve enough space.
@@ -249,13 +362,13 @@ func (c *SizedLRU) Reserve(size int64) (bool, error) {
 		if ele != nil {
 			c.removeElement(ele)
 		} else {
-			return false, errReservation // This should have been caught at the start.
+			return internalErr(errReservation) // This should have been caught at the start.
 		}
 	}
 
 	c.currentSize += size
 	c.reservedSize += size
-	return true, nil
+	return nil
 }
 
 func (c *SizedLRU) Unreserve(size int64) error {
@@ -287,10 +400,7 @@ func (c *SizedLRU) removeElement(e *list.Element) {
 	c.currentSize -= roundUp4k(kv.value.sizeOnDisk)
 	c.uncompressedSize -= roundUp4k(kv.value.size)
 	c.counterEvictedBytes.Add(float64(kv.value.sizeOnDisk))
-
-	if c.onEvict != nil {
-		c.onEvict(kv.key, kv.value)
-	}
+	c.appendEvictionToQueue(kv)
 }
 
 // Round n up to the nearest multiple of BlockSize (4096).
@@ -306,4 +416,58 @@ func (c *SizedLRU) getTailItem() (Key, lruItem) {
 		return kv.key, kv.value
 	}
 	return nil, lruItem{}
+}
+
+// Append an entry to the eviction queue. The entry must have been removed
+// from SizedLRU.ll before being sent to this method.
+//
+// The diskCache.mu mutex should be held when invoking this method (to prevent
+// queuedEvictionsChan from potentially becoming full and blocking calls).
+func (c *SizedLRU) appendEvictionToQueue(e *entry) {
+	c.queuedEvictionsSize.Add(e.value.sizeOnDisk)
+
+	select {
+	case queuedEvictions := <-c.queuedEvictionsChan:
+		c.queuedEvictionsChan <- append(queuedEvictions, e)
+	default:
+		c.queuedEvictionsChan <- []*entry{e}
+	}
+}
+
+// Block waiting for a slice of evicted entries and then remove them from
+// file system. Note that the slice could conceivably contain millions of
+// entries in am overload situation. Note that this method may be invoked
+// without holding the diskCache.mu mutex.
+func (c *SizedLRU) performQueuedEvictions() {
+
+	sliceOfEntries := <-c.queuedEvictionsChan
+
+	for _, kv := range sliceOfEntries {
+		c.onEvict(kv.key, kv.value)
+		c.queuedEvictionsSize.Add(-kv.value.sizeOnDisk)
+	}
+}
+
+// Note that this method may be invoked without holding the diskCache.mu mutex.
+func (c *SizedLRU) performQueuedEvictionsContinuously() {
+	for {
+		c.performQueuedEvictions()
+	}
+}
+
+// Note that this function only needs to be called when the disk size usage
+// can grow (e.g., from Reserve and Add, but not from Remove).
+// Note that diskCache.mu mutex must be held when invoking this method.
+func (c *SizedLRU) calcTotalDiskSizeAndUpdatePeak(sizeOfNewFile int64) uint64 {
+	totalDiskSizeNow := uint64(c.currentSize) + uint64(c.queuedEvictionsSize.Load()) + uint64(sizeOfNewFile)
+	if totalDiskSizeNow > c.totalDiskSizePeak {
+		c.totalDiskSizePeak = totalDiskSizeNow
+	}
+	return totalDiskSizeNow
+}
+
+// Note that diskCache.mu mutex must be held when invoking this method.
+func (c *SizedLRU) shiftToNextMetricPeriod() {
+	c.gaugeCacheSizeBytes.Set(float64(c.totalDiskSizePeak))
+	c.totalDiskSizePeak = uint64(c.currentSize) + uint64(c.queuedEvictionsSize.Load())
 }

--- a/cache/disk/options.go
+++ b/cache/disk/options.go
@@ -14,8 +14,9 @@ import (
 type Option func(*CacheConfig) error
 
 type CacheConfig struct {
-	diskCache *diskCache        // Assumed to be non-nil.
-	metrics   *metricsDecorator // May be nil.
+	diskCache        *diskCache        // Assumed to be non-nil.
+	metrics          *metricsDecorator // May be nil.
+	maxSizeHardLimit int64
 }
 
 func WithStorageMode(mode string) Option {
@@ -105,6 +106,13 @@ func WithEndpointMetrics() Option {
 		c.metrics.counter.WithLabelValues("get", "ac", "hit").Add(0)
 		c.metrics.counter.WithLabelValues("get", "ac", "miss").Add(0)
 
+		return nil
+	}
+}
+
+func WithMaxSizeHardLimit(maxSizeHardLimit int64) Option {
+	return func(cc *CacheConfig) error {
+		cc.maxSizeHardLimit = maxSizeHardLimit
 		return nil
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	ProfileAddress              string                    `yaml:"profile_address"`
 	Dir                         string                    `yaml:"dir"`
 	MaxSize                     int                       `yaml:"max_size"`
+	MaxSizeHardLimit            int                       `yaml:"max_size_hard_limit"`
 	StorageMode                 string                    `yaml:"storage_mode"`
 	ZstdImplementation          string                    `yaml:"zstd_implementation"`
 	HtpasswdFile                string                    `yaml:"htpasswd_file"`
@@ -182,6 +183,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 	httpWriteTimeout time.Duration,
 	accessLogLevel string,
 	logTimezone string,
+	maxSizeHardLimit int,
 	maxBlobSize int64,
 	maxProxyBlobSize int64) (*Config, error) {
 
@@ -191,6 +193,7 @@ func newFromArgs(dir string, maxSize int, storageMode string, zstdImplementation
 		ProfileAddress:              profileAddress,
 		Dir:                         dir,
 		MaxSize:                     maxSize,
+		MaxSizeHardLimit:            maxSizeHardLimit,
 		StorageMode:                 storageMode,
 		ZstdImplementation:          zstdImplementation,
 		HtpasswdFile:                htpasswdFile,
@@ -673,6 +676,7 @@ func get(ctx *cli.Context) (*Config, error) {
 		ctx.Duration("http_write_timeout"),
 		ctx.String("access_log_level"),
 		ctx.String("log_timezone"),
+		ctx.Int("max_size_hard_limit"),
 		ctx.Int64("max_blob_size"),
 		ctx.Int64("max_proxy_blob_size"),
 	)

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func run(ctx *cli.Context) error {
 		disk.WithZstdImplementation(c.ZstdImplementation),
 		disk.WithMaxBlobSize(c.MaxBlobSize),
 		disk.WithProxyMaxBlobSize(c.MaxProxyBlobSize),
+		disk.WithMaxSizeHardLimit(int64(c.MaxSizeHardLimit) * 1024 * 1024 * 1024),
 		disk.WithAccessLogger(c.AccessLogger),
 	}
 	if c.ProxyBackend != nil {

--- a/server/grpc.go
+++ b/server/grpc.go
@@ -245,6 +245,10 @@ func gRPCErrCode(err error, dflt codes.Code) codes.Code {
 		return codes.OK
 	}
 
+	if err == disk.ErrOverloaded {
+		return codes.ResourceExhausted
+	}
+
 	cerr, ok := err.(*cache.Error)
 	if ok && cerr.Code == http.StatusBadRequest {
 		return codes.InvalidArgument

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -76,7 +76,7 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 		rdr, sizeBytes, err := s.cache.Get(ctx, cache.AC, req.ActionDigest.Hash, unknownActionResultSize, 0)
 		if err != nil {
 			s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
-			return nil, status.Error(codes.Unknown, err.Error())
+			return nil, status.Error(gRPCErrCode(err, codes.Unknown), err.Error())
 		}
 		if rdr == nil || sizeBytes <= 0 {
 			s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, "NOT FOUND")
@@ -112,7 +112,7 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 	result, _, err := s.cache.GetValidatedActionResult(ctx, req.ActionDigest.Hash)
 	if err != nil {
 		s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
-		return nil, status.Error(codes.Unknown, err.Error())
+		return nil, status.Error(gRPCErrCode(err, codes.Unknown), err.Error())
 	}
 
 	if result == nil {
@@ -171,12 +171,6 @@ func (s *grpcServer) maybeInline(ctx context.Context, inline bool, slice *[]byte
 			return nil // Not inlined, nothing to do.
 		}
 
-		if (*digest).SizeBytes <= 0 {
-			// Unexpected corner case?
-			*slice = []byte{}
-			return nil
-		}
-
 		if *digest == nil {
 			hash := sha256.Sum256(*slice)
 			*digest = &pb.Digest{
@@ -191,8 +185,13 @@ func (s *grpcServer) maybeInline(ctx context.Context, inline bool, slice *[]byte
 				bytes.NewReader(*slice))
 			if err == nil || err == io.EOF {
 				s.accessLogger.Printf("GRPC CAS PUT %s OK", (*digest).Hash)
+			} else {
+				// De-inline failed (possibly due to "resource overload"). Preserve
+				// inlined data regardless of desire to de-inline.
+				s.accessLogger.Printf("GRPC CAS PUT %s %s", (*digest).Hash, err)
+				*inlinedSoFar += int64(len(*slice))
+				return nil
 			}
-			// De-inline failed (possibly due to "resource overload"), that's OK though.
 		}
 
 		*slice = []byte{}
@@ -267,7 +266,7 @@ func (s *grpcServer) UpdateActionResult(ctx context.Context,
 	err = s.cache.Put(ctx, cache.AC, req.ActionDigest.Hash,
 		int64(len(data)), bytes.NewReader(data))
 	if err != nil && err != io.EOF {
-		s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
+		s.logErrorPrintf(err, "%s %s %s", logPrefix, req.ActionDigest.Hash, err)
 		code := gRPCErrCode(err, codes.Internal)
 		return nil, status.Error(code, err.Error())
 	}
@@ -291,7 +290,7 @@ func (s *grpcServer) UpdateActionResult(ctx context.Context,
 			err = s.cache.Put(ctx, cache.CAS, f.Digest.Hash,
 				f.Digest.SizeBytes, bytes.NewReader(f.Contents))
 			if err != nil && err != io.EOF {
-				s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
+				s.logErrorPrintf(err, "%s %s %s", logPrefix, req.ActionDigest.Hash, err)
 				code := gRPCErrCode(err, codes.Internal)
 				return nil, status.Error(code, err.Error())
 			}
@@ -314,7 +313,7 @@ func (s *grpcServer) UpdateActionResult(ctx context.Context,
 		err = s.cache.Put(ctx, cache.CAS, hash, sizeBytes,
 			bytes.NewReader(req.ActionResult.StdoutRaw))
 		if err != nil && err != io.EOF {
-			s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
+			s.logErrorPrintf(err, "%s %s %s", logPrefix, req.ActionDigest.Hash, err)
 			code := gRPCErrCode(err, codes.Internal)
 			return nil, status.Error(code, err.Error())
 		}
@@ -336,7 +335,7 @@ func (s *grpcServer) UpdateActionResult(ctx context.Context,
 		err = s.cache.Put(ctx, cache.CAS, hash, sizeBytes,
 			bytes.NewReader(req.ActionResult.StderrRaw))
 		if err != nil && err != io.EOF {
-			s.accessLogger.Printf("%s %s %s", logPrefix, req.ActionDigest.Hash, err)
+			s.logErrorPrintf(err, "%s %s %s", logPrefix, req.ActionDigest.Hash, err)
 			code := gRPCErrCode(err, codes.Internal)
 			return nil, status.Error(code, err.Error())
 		}

--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -21,11 +21,7 @@ import (
 	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"github.com/buchgr/bazel-remote/v2/cache"
-	"github.com/buchgr/bazel-remote/v2/cache/disk"
-
-
 )
-
 
 // FetchServer implementation
 
@@ -185,7 +181,7 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 			}, nil
 		}
 
-		if err == disk.ErrOverloaded {
+		if translateGRPCErrCodeFromClient(err) == codes.ResourceExhausted {
 			return &resourceExhaustedResponse, nil
 		}
 

--- a/server/grpc_asset.go
+++ b/server/grpc_asset.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -20,12 +21,23 @@ import (
 	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 
 	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk"
+
+
 )
+
 
 // FetchServer implementation
 
 var errNilFetchBlobRequest = grpc_status.Error(codes.InvalidArgument,
 	"expected a non-nil *FetchBlobRequest")
+
+var resourceExhaustedResponse = asset.FetchBlobResponse{
+	Status: &status.Status{
+		Code:    int32(codes.ResourceExhausted),
+		Message: "Storage appears to be falling behind",
+	},
+}
 
 func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest) (*asset.FetchBlobResponse, error) {
 
@@ -161,8 +173,8 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 			}
 		}
 
-		ok, actualHash, size := s.fetchItem(ctx, uri, uriSpecificHeader, sha256Str)
-		if ok {
+		actualHash, size, err := s.fetchItem(ctx, uri, uriSpecificHeader, sha256Str)
+		if err == nil {
 			return &asset.FetchBlobResponse{
 				Status: &status.Status{Code: int32(codes.OK)},
 				BlobDigest: &pb.Digest{
@@ -173,6 +185,10 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 			}, nil
 		}
 
+		if err == disk.ErrOverloaded {
+			return &resourceExhaustedResponse, nil
+		}
+
 		// Not a simple file. Not yet handled...
 	}
 
@@ -181,22 +197,22 @@ func (s *grpcServer) FetchBlob(ctx context.Context, req *asset.FetchBlobRequest)
 	}, nil
 }
 
-func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Header, expectedHash string) (bool, string, int64) {
+func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Header, expectedHash string) (string, int64, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		s.errorLogger.Printf("unable to parse URI: %s err: %v", uri, err)
-		return false, "", int64(-1)
+		return "", int64(-1), err
 	}
 
 	if u.Scheme != "http" && u.Scheme != "https" {
 		s.errorLogger.Printf("unsupported URI: %s", uri)
-		return false, "", int64(-1)
+		return "", int64(-1), fmt.Errorf("Unknown URL scheme: %q", u.Scheme)
 	}
 
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		s.errorLogger.Printf("failed to create http.Request: %s err: %v", uri, err)
-		return false, "", int64(-1)
+		return "", int64(-1), err
 	}
 
 	req.Header = headers
@@ -204,14 +220,14 @@ func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Hea
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		s.errorLogger.Printf("failed to get URI: %s err: %v", uri, err)
-		return false, "", int64(-1)
+		return "", int64(-1), err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	rc := resp.Body
 
 	s.accessLogger.Printf("GRPC ASSET FETCH %s %s", uri, resp.Status)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return false, "", int64(-1)
+		return "", int64(-1), fmt.Errorf("Unsuccessful HTTP status code: %d", resp.StatusCode)
 	}
 
 	expectedSize := resp.ContentLength
@@ -221,7 +237,7 @@ func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Hea
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			s.errorLogger.Printf("failed to read data: %v", uri)
-			return false, "", int64(-1)
+			return "", int64(-1), err
 		}
 
 		expectedSize = int64(len(data))
@@ -231,7 +247,7 @@ func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Hea
 		if expectedHash != "" && hashStr != expectedHash {
 			s.errorLogger.Printf("URI data has hash %s, expected %s",
 				hashStr, expectedHash)
-			return false, "", int64(-1)
+			return "", int64(-1), fmt.Errorf("URI data has hash %s, expected %s", hashStr, expectedHash)
 		}
 
 		expectedHash = hashStr
@@ -241,10 +257,10 @@ func (s *grpcServer) fetchItem(ctx context.Context, uri string, headers http.Hea
 	err = s.cache.Put(ctx, cache.CAS, expectedHash, expectedSize, rc)
 	if err != nil && err != io.EOF {
 		s.errorLogger.Printf("failed to Put %s: %v", expectedHash, err)
-		return false, "", int64(-1)
+		return "", int64(-1), err
 	}
 
-	return true, expectedHash, expectedSize
+	return expectedHash, expectedSize, nil
 }
 
 func (s *grpcServer) FetchDirectory(context.Context, *asset.FetchDirectoryRequest) (*asset.FetchDirectoryResponse, error) {

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -537,6 +537,7 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 			}
 			return nil
 		}
+
 		if err == nil {
 			// Unexpected early return. Should not happen.
 			msg := fmt.Sprintf("GRPC BYTESTREAM WRITE INTERNAL ERROR %s", resourceName)
@@ -546,7 +547,7 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 
 		msg := fmt.Sprintf("GRPC BYTESTREAM WRITE CACHE ERROR: %s %v", resourceName, err)
 		s.accessLogger.Printf(msg)
-		return status.Error(codes.Internal, msg)
+		return status.Error(gRPCErrCode(err, codes.Internal), msg)
 	}
 
 	select {

--- a/server/grpc_bytestream.go
+++ b/server/grpc_bytestream.go
@@ -546,7 +546,7 @@ func (s *grpcServer) Write(srv bytestream.ByteStream_WriteServer) error {
 		}
 
 		msg := fmt.Sprintf("GRPC BYTESTREAM WRITE CACHE ERROR: %s %v", resourceName, err)
-		s.accessLogger.Printf(msg)
+		s.logErrorPrintf(err, msg)
 		return status.Error(gRPCErrCode(err, codes.Internal), msg)
 	}
 

--- a/server/grpc_cas.go
+++ b/server/grpc_cas.go
@@ -121,7 +121,7 @@ func (s *grpcServer) BatchUpdateBlobs(ctx context.Context,
 		err = s.cache.Put(ctx, cache.CAS, req.Digest.Hash,
 			int64(len(req.Data)), bytes.NewReader(req.Data))
 		if err != nil && err != io.EOF {
-			s.errorLogger.Printf("%s %s %s", errorPrefix, req.Digest.Hash, err)
+			s.logErrorPrintf(err, "%s %s %s", errorPrefix, req.Digest.Hash, err)
 			rr.Status.Code = int32(gRPCErrCode(err, codes.Internal))
 			continue
 		}
@@ -181,15 +181,21 @@ func (s *grpcServer) getBlobResponse(ctx context.Context, digest *pb.Digest, all
 		if rc != nil {
 			defer func() { _ = rc.Close() }()
 		}
-		if rc == nil || foundSize != digest.SizeBytes {
-			s.accessLogger.Printf("GRPC CAS GET %s NOT FOUND", digest.Hash)
-			r.Status = &status.Status{Code: int32(code.Code_NOT_FOUND)}
-			return &r
-		}
 
 		if err != nil {
 			s.errorLogger.Printf("GRPC CAS GET %s INTERNAL ERROR: %v", digest.Hash, err)
-			r.Status = &status.Status{Code: int32(code.Code_INTERNAL)}
+			// Using codes.NotFound as default, in order to keep historical behaviour.
+			// That ensures that clients handle for example corrupted headers
+			// as normal cache misses and allows clients to gracefully replace corrupted
+			// entries on disk by new uploads.
+			// The drawback is that it hides the real reason in e.g. prometheus metrics.
+			r.Status = &status.Status{Code: int32(gRPCErrCode(err, codes.NotFound))}
+			return &r
+		}
+
+		if rc == nil || foundSize != digest.SizeBytes {
+			s.accessLogger.Printf("GRPC CAS GET %s NOT FOUND", digest.Hash)
+			r.Status = &status.Status{Code: int32(code.Code_NOT_FOUND)}
 			return &r
 		}
 
@@ -216,7 +222,10 @@ func (s *grpcServer) getBlobResponse(ctx context.Context, digest *pb.Digest, all
 	if err != nil {
 		s.errorLogger.Printf("GRPC CAS GET %s INTERNAL ERROR: %v",
 			digest.Hash, err)
-		r.Status = &status.Status{Code: int32(code.Code_INTERNAL)}
+		// TODO The case above with allowZstd have codes.NotFound as default
+		//      for unknown erros, but this has codes.Internal. Is that difference
+		//      intentional?
+		r.Status = &status.Status{Code: int32(gRPCErrCode(err, codes.Internal))}
 		return &r
 	}
 

--- a/server/http.go
+++ b/server/http.go
@@ -426,11 +426,18 @@ func (h *httpCache) CacheHandler(w http.ResponseWriter, r *http.Request) {
 			if cerr, ok := err.(*cache.Error); ok {
 				msg = cerr.Text
 				http.Error(w, msg, cerr.Code)
+				if cerr.Code == http.StatusInsufficientStorage {
+					// Using accessLogger to prevent too verbose logging
+					// to errorLogger.
+					h.logResponse(cerr.Code, r)
+				} else {
+					h.errorLogger.Printf("PUT %s: %s", path(kind, hash), msg)
+				}
 			} else {
 				msg = "Unexpected error adding item to cache: " + err.Error()
 				http.Error(w, msg, http.StatusInternalServerError)
+				h.errorLogger.Printf("PUT %s: %s", path(kind, hash), msg)
 			}
-			h.errorLogger.Printf("PUT %s: %s", path(kind, hash), msg)
 		} else {
 			h.logResponse(http.StatusOK, r)
 		}

--- a/utils/BUILD.bazel
+++ b/utils/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/buchgr/bazel-remote/v2/utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//cache:go_default_library",
         "//genproto/build/bazel/remote/execution/v2:go_default_library",
     ],
 )

--- a/utils/flags/flags.go
+++ b/utils/flags/flags.go
@@ -51,6 +51,14 @@ func GetCliFlags() []cli.Flag {
 			Usage:   "The maximum size of bazel-remote's disk cache in GiB. This flag is required.",
 			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE"},
 		},
+		&cli.Int64Flag{
+			Name:  "max_size_hard_limit",
+			Value: -1,
+			Usage: "If enabled, the maximum size of bazel-remote's disk cache including files queued " +
+				"for eviction in GiB, before bazel-remote will reject write requests. A reasonable " +
+				"value might be 5% larger than --max_size.",
+			EnvVars: []string{"BAZEL_REMOTE_MAX_SIZE_HARD_LIMIT"},
+		},
 		&cli.StringFlag{
 			Name:    "storage_mode",
 			Value:   "zstd",

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -4,11 +4,13 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"log"
 	"os"
 	"testing"
 
+	"github.com/buchgr/bazel-remote/v2/cache"
 	pb "github.com/buchgr/bazel-remote/v2/genproto/build/bazel/remote/execution/v2"
 )
 
@@ -53,4 +55,56 @@ func RandomDataAndDigest(size int64) ([]byte, pb.Digest) {
 // for tests.
 func NewSilentLogger() *log.Logger {
 	return log.New(io.Discard, "", 0)
+}
+
+// AssertEquals fails the test if expected and actual values are not equal.
+// It works with any comparable type.
+func AssertEquals[T comparable](t *testing.T, expected T, actual T) {
+	t.Helper()
+	if expected != actual {
+		t.Fatalf("Expected %v, but got %v.", expected, actual)
+	}
+}
+
+// AssertSuccess asserts that the provided result represents a successful outcome.
+//
+// The success criteria are:
+// - nil value (e.g., no error)
+// - true boolean
+//
+// The failure criteria are:
+// - non-nil error
+// - false boolean
+func AssertSuccess(t *testing.T, result interface{}) {
+	t.Helper()
+	switch v := result.(type) {
+	case nil:
+		return // Success as expected
+	case error:
+		if v != nil {
+			t.Fatalf("Expected success, but got error: %v", v)
+		}
+	case bool:
+		if !v {
+			t.Fatalf("Expected success, but got false value")
+		}
+	default:
+		t.Fatalf("Unsupported type: %T", v)
+	}
+}
+
+// AssertFailureWithCode asserts that the provided error is a *cache.Error with the expected code.
+func AssertFailureWithCode(t *testing.T, err error, expectedCode int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Expected failure, but got no error.")
+	}
+	var cerr *cache.Error
+	if errors.As(err, &cerr) {
+		if cerr.Code != expectedCode {
+			t.Fatalf("Error code mismatch: expected %d, got %d", expectedCode, cerr.Code)
+		}
+	} else {
+		t.Fatalf("Expected error of type *Error, got %T", err)
+	}
 }


### PR DESCRIPTION
* Perform evictions from a single background goroutine that receives files to be removed via a channel.
* Throttle the number of concurrent Put requests and proxied Get requests (because they result in an implicit Put).
* Add a new (optional) max_size_hard_limit configuration setting, which specifies when the server should start rejecting new write requests.

A reasonable starting point for max_size_hard_limit might be ~5% larger than max_size. It can be fine-tined by watching how the prometheus query max_over_time(bazel_remote_disk_cache_size_bytes[$__interval]) varies between bazel_remote_disk_cache_size_bytes_limit{type="evict"} and bazel_remote_disk_cache_size_bytes_limit{type="reject"}.

This helps to avoid crashes due to hitting the go runtime's default limit of 10,000 operating system threads when under high load. It also makes cache eviction ~3 times faster, and gives up to 70% higher write throughput when there are lots of cache evictions.

The cache can grow above max_size when asynchronous file removals cannot keep up with new file writes.

This is a rebase + cleanup of #639 + #696.