### PR TITLE
Replace entry.Key interface with string

### DIFF
--- a/cache/disk/disk_test.go
+++ b/cache/disk/disk_test.go
@@ -454,10 +454,10 @@ func TestCacheExistingFiles(t *testing.T) {
 	}
 	testCache := testCacheI.(*diskCache)
 
-	evicted := []Key{}
+	evicted := []string{}
 	origOnEvict := testCache.lru.onEvict
-	testCache.lru.onEvict = func(key Key, value lruItem) {
-		evicted = append(evicted, key.(string))
+	testCache.lru.onEvict = func(key string, value lruItem) {
+		evicted = append(evicted, key)
 		origOnEvict(key, value)
 	}
 

--- a/cache/disk/load.go
+++ b/cache/disk/load.go
@@ -583,7 +583,7 @@ func (c *diskCache) loadExistingFiles(maxSizeBytes int64, cc CacheConfig) error 
 	// The eviction callback deletes the file from disk.
 	// This function is only called while the lock is not held
 	// by the current goroutine.
-	onEvict := func(key Key, value lruItem) {
+	onEvict := func(key string, value lruItem) {
 		f := c.getElementPath(key, value)
 		c.removeFile(f)
 	}


### PR DESCRIPTION
We only use non-string Keys in tests, so let's change the tests to use strings also and drop the interface{}.