### PR TITLE
fix azure auth regression in 2.6.0

### DIFF
--- a/cache/azblobproxy/azblobproxy.go
+++ b/cache/azblobproxy/azblobproxy.go
@@ -144,7 +144,9 @@ func New(
 	var err error
 	var client *azblob.Client
 
-	if creds == nil && len(sharedKey) > 0 {
+	if creds != nil {
+		client, err = azblob.NewClient(url, creds, nil)
+	} else if len(sharedKey) > 0 {
 		cred, e := azblob.NewSharedKeyCredential(storageAccount, sharedKey)
 		if e != nil {
 			log.Fatalln(e)


### PR DESCRIPTION
changes in 2.6.0 meant that azure blob storage only supported shared key authentication or no authentication: When valid credentials were passed in, and no shared key was present in configuration, this would result in a NewClientWithNoCredential being created, the credentials were ignored