### PR TITLE
Fix Bazel Downstream error

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,8 @@ bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "rules_oci", version = "2.2.6")
+
+# TODO: Remove `aspect_bazel_lib` as a direct dep once higher version of `rules_oci` is available
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")


### PR DESCRIPTION
This fixes [Bazel Downstream error](https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/4962#019974c2-82da-487a-8f8f-84233f6f169a).

Newer version of `aspect_bazel_lib` is needed due to removal of `incompatible_use_toolchain_transition` as a `rule` attribute. 

Note that `aspect_bazel_lib` is a transitive dependency, used by `rules_oci`. Still, `rules_oci` is already using it's current highest version (it can be updated in the future). 