### PR TITLE
[zstd] Build zstd library

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,9 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 bazel_dep(name = "rules_oci", version = "2.2.6")
 
+# Ensure this version of the libzstd is supported by github.com/valyala/gozstd.
+bazel_dep(name = "zstd", version = "1.5.7.bcr.1")
+
 # TODO: Remove `aspect_bazel_lib` as a direct dep once higher version of `rules_oci` is available.
 # See also: https://github.com/bazel-contrib/rules_oci/pull/842
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
@@ -20,6 +23,7 @@ oci.pull(
     tag = "nonroot-amd64",
 )
 use_repo(oci, "cgo_amd64_base")
+
 oci.pull(
     name = "cgo_arm64_base",
     image = "gcr.io/distroless/base-nossl-debian12",
@@ -136,3 +140,5 @@ use_repo(
     "org_golang_x_oauth2",
     "org_golang_x_sync",
 )
+
+inject_repo(go_deps, "zstd")

--- a/patches/gozstd.patch
+++ b/patches/gozstd.patch
@@ -3,33 +3,8 @@ new file mode 100644
 index 0000000..2dd6245
 --- /dev/null
 +++ b/BUILD.bazel
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,51 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-+load("@rules_cc//cc:cc_library.bzl", "cc_library")
-+
-+cc_library(
-+    name = "libzstd",
-+    srcs = select({
-+        "@io_bazel_rules_go//go/platform:android_amd64": ["libzstd_linux_amd64.a"],
-+        "@io_bazel_rules_go//go/platform:android_arm": ["libzstd_linux_arm.a"],
-+        "@io_bazel_rules_go//go/platform:android_arm64": ["libzstd_linux_arm64.a"],
-+        "@io_bazel_rules_go//go/platform:darwin_amd64": ["libzstd_darwin_amd64.a"],
-+        "@io_bazel_rules_go//go/platform:darwin_arm64": ["libzstd_darwin_arm64.a"],
-+        "@io_bazel_rules_go//go/platform:freebsd_amd64": ["libzstd_freebsd_amd64.a"],
-+        "@io_bazel_rules_go//go/platform:ios_amd64": ["libzstd_darwin_amd64.a"],
-+        "@io_bazel_rules_go//go/platform:ios_arm64": ["libzstd_darwin_arm64.a"],
-+        "@io_bazel_rules_go//go/platform:linux_amd64": ["libzstd_linux_amd64.a"],
-+        "@io_bazel_rules_go//go/platform:linux_arm": ["libzstd_linux_arm.a"],
-+        "@io_bazel_rules_go//go/platform:linux_arm64": ["libzstd_linux_arm64.a"],
-+        "@io_bazel_rules_go//go/platform:windows_amd64": ["libzstd_windows_amd64.a"],
-+        "//conditions:default": ["UNSUPPORTED_PLATFORM"],
-+    }),
-+    hdrs = [
-+        "zdict.h",
-+        "zstd.h",
-+        "zstd_errors.h",
-+    ],
-+)
 +
 +go_library(
 +    name = "gozstd",
@@ -48,7 +23,7 @@ index 0000000..2dd6245
 +        "stream.go",
 +        "writer.go",
 +    ],
-+    cdeps = [":libzstd"],
++    cdeps = ["@zstd"],
 +    cgo = True,
 +    copts = ["-O3"],
 +    importpath = "github.com/valyala/gozstd",


### PR DESCRIPTION
Build the zstd library to avoid to use the pre-compiled libraries provided by the github.com/valyala/gozstd Go library.

This provides more flexibility to use any cross-compiler to build the bazel-remote binary.

Could resolve #869