### PR TITLE
grpcproxy: fix CAS writes and AC reads failing against strict gRPC backends

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -7,6 +7,14 @@ import (
 	"io"
 )
 
+type contextKey int
+
+const (
+	// ActionDigestSizeBytesKey carries the action digest size_bytes to the proxy,
+	// which needs it to issue a valid GetActionResult request.
+	ActionDigestSizeBytesKey contextKey = iota
+)
+
 // EntryKind describes the kind of cache entry
 type EntryKind int
 

--- a/cache/grpcproxy/grpcproxy.go
+++ b/cache/grpcproxy/grpcproxy.go
@@ -297,9 +297,15 @@ func (r *remoteGrpcProxyCache) Get(ctx context.Context, kind cache.EntryKind, ha
 		// is enabled. We can treat them as AC in this scope
 		fallthrough
 	case cache.AC:
+		actionDigestSize := int64(-1)
+		if v := ctx.Value(cache.ActionDigestSizeBytesKey); v != nil {
+			if sz, ok := v.(int64); ok {
+				actionDigestSize = sz
+			}
+		}
 		digest := pb.Digest{
 			Hash:      hash,
-			SizeBytes: size,
+			SizeBytes: actionDigestSize,
 		}
 
 		req := &pb.GetActionResultRequest{ActionDigest: &digest}

--- a/cache/grpcproxy/grpcproxy.go
+++ b/cache/grpcproxy/grpcproxy.go
@@ -299,7 +299,7 @@ func (r *remoteGrpcProxyCache) Get(ctx context.Context, kind cache.EntryKind, ha
 	case cache.AC:
 		digest := pb.Digest{
 			Hash:      hash,
-			SizeBytes: -1,
+			SizeBytes: size,
 		}
 
 		req := &pb.GetActionResultRequest{ActionDigest: &digest}

--- a/server/grpc_ac.go
+++ b/server/grpc_ac.go
@@ -70,6 +70,10 @@ func (s *grpcServer) GetActionResult(ctx context.Context,
 	// checked by the the disk cache.
 	const unknownActionResultSize = -1
 
+	// Thread the action digest size_bytes to the proxy via context; the
+	// Proxy.Get interface only carries the (unknown) ActionResult size.
+	ctx = context.WithValue(ctx, cache.ActionDigestSizeBytesKey, req.ActionDigest.SizeBytes)
+
 	if !s.depsCheck {
 		logPrefix = "GRPC AC GET NODEPSCHECK"
 


### PR DESCRIPTION
## Errors

When using the gRPC proxy backend, both CAS write-throughs and AC read-throughs fail against gRPC cache backends that strictly enforce the Remote Execution API spec.

**CAS writes** fail with `finished_writing='false'`:
```
GRPC PROXY WRITE CAS ...: rpc error: code = InvalidArgument desc = Request completed before all data was sent: digest='.../167222', actual_size='167222', finished_writing='false'
```

Then after partially fixing that, with `write_offset=0`:
```
GRPC PROXY WRITE CAS ...: rpc error: code = InvalidArgument desc = write_offset: Current write_offset (0) does not match expected one (4572)
```

**AC reads** fail with an invalid digest:
```
GRPC PROXY GET AC ...: rpc error: code = InvalidArgument desc = action_digest: invalid or missing action digest
```

## Root causes

**1. `finish_write` never set on the final ByteStream `WriteRequest`**

The ByteStream protocol requires the last `WriteRequest` to have `finish_write = true` to signal upload completion. The previous loop never set it — calling `CloseAndRecv()` alone is not sufficient for backends that require an explicit terminal message.

**2. `write_offset` not tracked across chunks**

Each `WriteRequest` must carry the cumulative byte offset of data sent so far. The previous implementation always sent `write_offset = 0`, causing backends to reject multi-chunk uploads.

**3. Action digest `size_bytes` sent as `-1` in `GetActionResult`**

`grpc_ac.go` passes `unknownActionResultSize` (-1) to `cache.Get()` because the ActionResult size is not known at request time. The proxy was forwarding this same `-1` as `size_bytes` in the `GetActionResult` Digest, which backends reject.

The correct value is `ActionDigest.SizeBytes` from the client request (the size of the Action, not the ActionResult). Since the `Proxy.Get` interface doesn't carry the action digest size, it is threaded via `context.WithValue` using a package-level typed key.

## Fix

- Track `finishWrite` from `io.EOF` and set `FinishWrite: true` on the corresponding `WriteRequest`, handling both EOF-with-data (`n > 0`) and EOF-only (`n == 0`).
- Track a running `writeOffset` and include it in every `WriteRequest`.
- In `grpc_ac.go`, store `req.ActionDigest.SizeBytes` in context before calling `cache.Get()`. In the proxy's AC path, read it back to construct a valid `Digest` for `GetActionResult`.

## Validation

After deploying with these fixes and clearing the local disk cache to force proxy fallbacks, all CAS writes and AC reads succeed:
```
GRPC PROXY GET AC 4dfa76214a85a477dc124e75adfe9415d07ce06d6abedcf77513f1dc2b395738: Success
GRPC PROXY CONTAINS CAS ce443496d644a99cc58a1da41a40aaf18d356abec228f4e1864ff72702887105: Success
GRPC PROXY GET AC 7a04428fcdb0388652bc0193c22a9fa5249f54170dca5cb76622c101ee0c6e00: Success
GRPC PROXY GET AC fda4ef0d282774ed830a2492be005785fd7c5e68011cd523c45a9c458bb1d011: Success
GRPC PROXY GET AC 5f82c3f1c16e0bb4a00ad91c9018198d55243af7c4b55e1882759ee53e3fc248: Success
GRPC PROXY GET AC ae8217d7f508d073256d729f7b0b1b14affa20576c2c180904f1679bdd265c42: Success
GRPC PROXY GET AC 31ae1f5e45defefd1ff2338a4ebd96d34823c4030d50ec99f2b959ea78ebf65a: Success
GRPC PROXY GET AC ea8e8bc151329e536b073d202b2af4c701df28b6ce484e0da6ee10cbd6337837: Success
GRPC PROXY GET AC 5aab10c5e7a8f372b250bcc6b69403e85976e257f364d283577d552684a1b41e: Success
```