### PR TITLE
Allow systemd dynamic user

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -285,12 +285,6 @@ func (c *diskCache) Put(ctx context.Context, kind cache.EntryKind, hash string, 
 			if err != nil {
 				log.Printf("warning: failed to remove temp file: %q", blobFile)
 			}
-		} else if blobFile != "" {
-			// Mark the file as "complete".
-			err := os.Chmod(blobFile, tempfile.FinalMode)
-			if err != nil {
-				log.Println("failed to mark", blobFile, "as complete:", err)
-			}
 		}
 
 		if unreserve {
@@ -627,12 +621,6 @@ func (c *diskCache) get(ctx context.Context, kind cache.EntryKind, hash string, 
 			err := os.Remove(blobFile)
 			if err != nil {
 				log.Printf("warning: failed to remove temp file: %q", blobFile)
-			}
-		} else if blobFile != "" {
-			// Mark the file as "complete".
-			err := os.Chmod(blobFile, tempfile.FinalMode)
-			if err != nil {
-				log.Println("failed to mark", blobFile, "as complete:", err)
 			}
 		}
 

--- a/examples/bazel-remote.service
+++ b/examples/bazel-remote.service
@@ -14,6 +14,13 @@ Description=bazel-remote cache
 # to the cache directory specified in ExecStart below:
 User=bazel-remote
 Group=bazel-remote
+# Alternatively, use systemd DynamicUser= together with StateDirectory=.
+# This will automatically create a user and group, provision a writable
+# state directory, and sandbox the service.
+#
+# DynamicUser=true
+# StateDirectory=%N
+# ExecStart=/absolute/path/to/bazel-remote --max_size 1000 --dir ${STATE_DIRECTORY}
 
 # We need to have a lot of files open at once.
 LimitNOFILE=40000

--- a/utils/tempfile/tempfile.go
+++ b/utils/tempfile/tempfile.go
@@ -36,25 +36,13 @@ func (c *Creator) ranqd1() string {
 
 const flags = os.O_RDWR | os.O_CREATE | os.O_EXCL
 
-// The final permissions of the cache files, once they have finished
-// being uploaded.
-const FinalMode = 0664
-
-// The permissions to use for cache files that are still being uploaded.
-// The setgid bit will be unset when the upload has finished.
-const wipMode = FinalMode | os.ModeSetgid
+const mode = 0664
 
 var errNoTempfile = errors.New("failed to create a temp file")
 
 // Create attempts to create a file whose name is of the form
 // <base>-<randomstring> and with a ".v1" suffix if `legacy` is
-// true. The file will be created with the setgid bit set, which
-// indicates that it is not complete. The *os.File is returned
-// along with the random string, and an error if something went
-// wrong.
-//
-// Once the file has been successfully written by the caller, it
-// should be chmod'ed to `FinalMode` to mark it as complete.
+// true.
 func (c *Creator) Create(base string, legacy bool) (*os.File, string, error) {
 	var err error
 	var f *os.File
@@ -69,7 +57,7 @@ func (c *Creator) Create(base string, legacy bool) (*os.File, string, error) {
 			name = base + "-" + random
 		}
 
-		f, err = os.OpenFile(name, flags, wipMode)
+		f, err = os.OpenFile(name, flags, mode)
 		if err == nil {
 			return f, random, nil
 		}


### PR DESCRIPTION
This hack was originally added in 48feee2. Remove it in favor of using
DynamicUser= in the systemd service.

The problem here, as documented in systemd.exec(5), is that DynamicUser=
implicitly enables RestrictSUIDSGID= and cannot be disabled, which
breaks bazel-remote.

cc @mostynb 