### PR TITLE
If a cache entry can't be found on disk, remove the cache entry

### DIFF
--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -462,23 +462,29 @@ func (c *diskCache) availableOrTryProxy(kind cache.EntryKind, hash string, size 
 
 		if !isSizeMismatch(size, item.size) {
 			var f *os.File
+			fastPath := true
 			f, err = os.Open(blobPath)
 			if err != nil && os.IsNotExist(err) {
 				// Another request replaced the file before we could open it?
 				// Enter slow path.
+				fastPath = false
 
 				c.mu.Lock()
 				item, listElem = c.lru.Get(key)
 				if listElem != nil {
 					blobPath = path.Join(c.dir, c.FileLocation(kind, item.legacy, hash, item.size, item.random))
 					f, err = os.Open(blobPath)
+					if err != nil {
+						// We will log the error below, while not holding the lock.
+						c.lru.RemoveElement(listElem)
+					}
 				}
 				c.mu.Unlock()
 			}
 
 			if err != nil {
 				// Race condition, was the item purged after we released the lock?
-				log.Printf("Warning: expected %q to exist on disk, undersized cache?", blobPath)
+				log.Printf("Warning: expected %q to exist on disk (fast path: %t), undersized cache? Last reported error: %v", blobPath, fastPath, err)
 			} else if kind == cache.CAS {
 				var rc io.ReadCloser
 				if item.legacy {


### PR DESCRIPTION
Initial mitigation for #893.