### PR TITLE
disk cache: verify CAS digests fetched from a proxy backend

### DIFF
--- a/cache/disk/BUILD.bazel
+++ b/cache/disk/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "disk_test.go",
         "findmissing_test.go",
         "lru_test.go",
+        "proxy_verify_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/cache/disk/disk.go
+++ b/cache/disk/disk.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -355,6 +356,37 @@ func (c *diskCache) Put(ctx context.Context, kind cache.EntryKind, hash string, 
 	return nil
 }
 
+// Re-reads a compressed CAS blob just fetched from a proxy backend and confirms that
+// its logical bytes match their expected digest.
+func verifyCompressedCasBlob(zstd zstdimpl.ZstdImpl, blobFile string, hash string, size int64) error {
+	f, err := os.Open(blobFile)
+	if err != nil {
+		return err
+	}
+
+	rc, err := casblob.GetUncompressedReadCloser(zstd, f, size, 0)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+
+	hasher := sha256.New()
+	n, err := io.Copy(hasher, rc)
+	if err != nil {
+		return err
+	}
+	if n != size {
+		return fmt.Errorf("sizes don't match. Expected %d, found %d", size, n)
+	}
+
+	actualHash := hex.EncodeToString(hasher.Sum(nil))
+	if actualHash != hash {
+		return fmt.Errorf("checksums don't match. Expected %s, found %s", hash, actualHash)
+	}
+
+	return nil
+}
+
 func (c *diskCache) writeAndCloseFile(ctx context.Context, r io.Reader, kind cache.EntryKind, hash string, size int64, f *os.File) (int64, error) {
 	closeFile := true
 	defer func() {
@@ -691,6 +723,7 @@ func (c *diskCache) get(ctx context.Context, kind cache.EntryKind, hash string, 
 	}
 
 	legacy := kind == cache.CAS && c.storageMode == casblob.Identity
+	compressed := kind == cache.CAS && !legacy
 
 	blobPathBase := path.Join(c.dir, c.FileLocationBase(kind, legacy, hash, foundSize))
 	tf, random, err := tfc.Create(blobPathBase, legacy)
@@ -701,11 +734,37 @@ func (c *diskCache) get(ctx context.Context, kind cache.EntryKind, hash string, 
 
 	blobFile = tf.Name()
 
+	// Don't trust a proxy backend to return the blob that was asked for. Validate it has expected digest.
 	var sizeOnDisk int64
-	sizeOnDisk, err = io.Copy(tf, r)
-	_ = tf.Close()
+	if legacy {
+		verifier := sha256verifier.New(hash, foundSize, tf)
+		sizeOnDisk, err = io.Copy(verifier, r)
+		if err == nil {
+			// Closes tf too, and reports a size or digest mismatch.
+			err = verifier.Close()
+			if err != nil {
+				log.Printf("WARNING: proxy backend returned a bad CAS blob for %s: %v", hash, err)
+				return nil, -1, nil
+			}
+		} else {
+			_ = tf.Close()
+		}
+	} else {
+		// A compressed CAS blob is checked below. AC and raw entries are keyed by action
+		// digest, not by a hash of their contents, so nothing can check them.
+		sizeOnDisk, err = io.Copy(tf, r)
+		_ = tf.Close()
+	}
 	if err != nil {
 		return nil, -1, internalErr(err)
+	}
+
+	if compressed {
+		err = verifyCompressedCasBlob(c.zstd, blobFile, hash, foundSize)
+		if err != nil {
+			log.Printf("WARNING: proxy backend returned a bad CAS blob for %s: %v", hash, err)
+			return nil, -1, nil
+		}
 	}
 
 	rcf, err := os.Open(blobFile)

--- a/cache/disk/proxy_verify_test.go
+++ b/cache/disk/proxy_verify_test.go
@@ -1,0 +1,117 @@
+package disk
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/buchgr/bazel-remote/v2/cache"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/casblob"
+	"github.com/buchgr/bazel-remote/v2/cache/disk/zstdimpl"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
+)
+
+// lyingProxy implements cache.Proxy and answers every CAS request with the same blob, whose
+// contents never hash to the digest that was asked for.
+type lyingProxy struct {
+	// What the disk cache stores CAS blobs as, which is what a proxy backend hands back.
+	storageMode casblob.CompressionType
+}
+
+const lie = "goodbye"
+
+func hashOf(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func (p lyingProxy) Put(ctx context.Context, kind cache.EntryKind, hash string, logicalSize int64, sizeOnDisk int64, rc io.ReadCloser) {
+	_ = rc.Close()
+}
+
+func (p lyingProxy) Get(ctx context.Context, kind cache.EntryKind, hash string, _ int64) (io.ReadCloser, int64, error) {
+	if kind != cache.CAS {
+		return nil, -1, nil
+	}
+
+	// The caller is told the size it asked for, so the existing size checks cannot catch this.
+	if p.storageMode == casblob.Identity {
+		return io.NopCloser(strings.NewReader(lie[:contentsLength])), contentsLength, nil
+	}
+
+	tmpfile, err := os.CreateTemp("", "lyingProxyGet")
+	if err != nil {
+		return nil, -1, err
+	}
+	name := tmpfile.Name()
+	defer func() { _ = os.Remove(name) }()
+
+	zi, err := zstdimpl.Get("go")
+	if err != nil {
+		return nil, -1, err
+	}
+
+	// WriteAndClose verifies what it is given, so it has to be told the digest of the lie.
+	_, err = casblob.WriteAndClose(zi, strings.NewReader(lie[:contentsLength]), tmpfile,
+		casblob.Zstandard, hashOf(lie[:contentsLength]), contentsLength)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	readme, err := os.Open(name)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	return readme, contentsLength, nil
+}
+
+func (p lyingProxy) Contains(ctx context.Context, kind cache.EntryKind, hash string, _ int64) (bool, int64) {
+	if kind != cache.CAS {
+		return false, -1
+	}
+	return true, contentsLength
+}
+
+// A CAS blob whose contents do not hash to the digest they were fetched under must not be handed to
+// a client, nor left in the cache, whichever way the cache stores blobs on disk.
+func TestProxyReturnsWrongCasBlob(t *testing.T) {
+	for _, mode := range []string{"uncompressed", "zstd"} {
+		t.Run(mode, func(t *testing.T) {
+			compression := casblob.Identity
+			if mode == "zstd" {
+				compression = casblob.Zstandard
+			}
+
+			cacheDir := tempDir(t)
+			defer func() { _ = os.RemoveAll(cacheDir) }()
+
+			cacheI, err := New(cacheDir, BlockSize,
+				WithStorageMode(mode),
+				WithProxyBackend(lyingProxy{storageMode: compression}),
+				WithAccessLogger(testutils.NewSilentLogger()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			testCache := cacheI.(*diskCache)
+
+			rdr, _, err := testCache.Get(context.Background(), cache.CAS, contentsHash, contentsLength, 0)
+			if err != nil {
+				t.Fatalf("expected a cache miss, got an error: %v", err)
+			}
+			if rdr != nil {
+				data, _ := io.ReadAll(rdr)
+				_ = rdr.Close()
+				t.Fatalf("the cache returned a blob that does not match its digest: %q", data)
+			}
+
+			if testCache.lru.Len() != 0 {
+				t.Fatalf("expected the cache to be empty, found %d items", testCache.lru.Len())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, blobs fetched from a proxy backend were committed after only a size comparison. A backend answering with same-length wrong bytes got them stored under the digest they were asked for, and served to every client after that.

Verify proxy reads by -hashing their blobs and comparing before committing. A hash mismatch is logged, dropped and reported as a cache miss, similar to a size mismatch.

Client uploads already *are* verified that way, so this closes the verification gap for proxy mode.

-----

I'm trying to set up two bazel-remote instances chained over the HTTP protocol, as in #524: a developer-side instance with
`--http_proxy.url` pointing at a shared one, `--num_uploaders 0` so it never writes back. The shared instance is published read-only by a reverse proxy restricted to `GET` and `HEAD` (which makes it read-only). A mistake there lets anyone `PUT`, and with no digest check on the fetch side nothing downstream would notice.

Related:

- #32 asked whether CAS hashes should be verified at all and concluded in favour. This extends that to the one write path left out.
- #186 does the same job for AC and raw blobs, which this PR deliberately does not touch.
- #666, #870: proxy backends and cache directories in the field do return data bazel-remote did not write.
