### PR TITLE
s3proxy: skip uploading a blob the bucket already has

### DIFF
--- a/cache/s3proxy/BUILD.bazel
+++ b/cache/s3proxy/BUILD.bazel
@@ -23,5 +23,10 @@ go_test(
     name = "go_default_test",
     srcs = ["s3proxy_test.go"],
     embed = [":go_default_library"],
-    deps = ["//cache:go_default_library"],
+    deps = [
+        "//cache:go_default_library",
+        "//utils:go_default_library",
+        "@com_github_minio_minio_go_v7//:go_default_library",
+        "@com_github_minio_minio_go_v7//pkg/credentials:go_default_library",
+    ],
 )

--- a/cache/s3proxy/s3proxy.go
+++ b/cache/s3proxy/s3proxy.go
@@ -157,14 +157,30 @@ func logResponse(log cache.Logger, method, bucket, key string, err error) {
 }
 
 func (c *s3Cache) UploadFile(item backendproxy.UploadReq) {
+	defer func() { _ = item.Rc.Close() }()
+
+	ctx := context.Background()
+	key := c.objectKey(item.Hash, item.Kind)
+
+	// Avoid re-uploading already existing blobs. A HEAD request is much cheaper than the PUT, same
+	// as in the http proxy backend.
+	if _, err := c.mcore.StatObject(ctx, c.bucket, key, minio.StatObjectOptions{}); err == nil {
+		if c.updateTimestamps {
+			// keep the blob current (lifecycle rules)
+			c.UpdateModificationTimestamp(ctx, c.bucket, key)
+		}
+		logResponse(c.accessLogger, "SKIP UPLOAD", c.bucket, key, nil)
+		return
+	}
+
 	_, err := c.mcore.PutObject(
-		context.Background(),
-		c.bucket,                          // bucketName
-		c.objectKey(item.Hash, item.Kind), // objectName
-		item.Rc,                           // reader
-		item.SizeOnDisk,                   // objectSize
-		"",                                // md5base64
-		"",                                // sha256
+		ctx,
+		c.bucket,        // bucketName
+		key,             // objectName
+		item.Rc,         // reader
+		item.SizeOnDisk, // objectSize
+		"",              // md5base64
+		"",              // sha256
 		minio.PutObjectOptions{
 			UserMetadata: map[string]string{
 				"Content-Type": "application/octet-stream",
@@ -172,9 +188,7 @@ func (c *s3Cache) UploadFile(item backendproxy.UploadReq) {
 		}, // metadata
 	)
 
-	logResponse(c.accessLogger, "UPLOAD", c.bucket, c.objectKey(item.Hash, item.Kind), err)
-
-	_ = item.Rc.Close()
+	logResponse(c.accessLogger, "UPLOAD", c.bucket, key, err)
 }
 
 func (c *s3Cache) Put(ctx context.Context, kind cache.EntryKind, hash string, logicalSize int64, sizeOnDisk int64, rc io.ReadCloser) {

--- a/cache/s3proxy/s3proxy_test.go
+++ b/cache/s3proxy/s3proxy_test.go
@@ -1,9 +1,24 @@
 package s3proxy
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/buchgr/bazel-remote/v2/cache"
+	testutils "github.com/buchgr/bazel-remote/v2/utils"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
 func TestObjectKey(t *testing.T) {
@@ -34,5 +49,192 @@ func TestObjectKey(t *testing.T) {
 			t.Errorf("objectKeyV1 did not match. (result: '%s' expected: '%s'",
 				result, tc.expectedV1)
 		}
+	}
+}
+
+// mock bucket with request counters
+type testBucket struct {
+	srv *httptest.Server
+
+	mu       sync.Mutex
+	objects  map[string][]byte
+	requests int
+	heads    int
+	puts     int
+	copies   []objectCopy
+}
+
+// One copy the bucket was asked to make, as its destination key and its `bucket/key` source.
+type objectCopy struct {
+	destination string
+	source      string
+}
+
+func (b *testBucket) handler(w http.ResponseWriter, r *http.Request) {
+	key := strings.TrimPrefix(r.URL.Path, "/"+testBucketName+"/")
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.requests++
+
+	switch r.Method {
+	case http.MethodHead:
+		b.heads++
+		data, ok := b.objects[key]
+		if !ok {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		// minio rejects a stat response without a parseable one, and calls the object absent.
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.Header().Set("ETag", `"`+key+`"`)
+	case http.MethodGet:
+		data, ok := b.objects[key]
+		if !ok {
+			http.Error(w, "Not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(data)
+	case http.MethodPost:
+		// Refreshing an object's timestamp is a copy onto itself, which minio performs as a
+		// multipart upload: initiate, copy the single part, complete.
+		if r.URL.Query().Has("uploads") {
+			b.reply(w, `<InitiateMultipartUploadResult><UploadId>1</UploadId></InitiateMultipartUploadResult>`)
+			return
+		}
+		if r.URL.Query().Has("uploadId") {
+			b.reply(w, `<CompleteMultipartUploadResult><ETag>"1"</ETag></CompleteMultipartUploadResult>`)
+			return
+		}
+		http.Error(w, "unsupported POST "+r.URL.RawQuery, http.StatusBadRequest)
+	case http.MethodPut:
+		// One part of that copy, which names its source in a header and carries no body.
+		if source := r.Header.Get("x-amz-copy-source"); source != "" {
+			b.copies = append(b.copies, objectCopy{destination: key, source: source})
+			b.reply(w, `<CopyPartResult><ETag>"1"</ETag></CopyPartResult>`)
+			return
+		}
+		b.puts++
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
+		}
+		b.objects[key] = data
+	default:
+		http.Error(w, "unsupported method "+r.Method, http.StatusBadRequest)
+	}
+}
+
+func (b *testBucket) reply(w http.ResponseWriter, body string) {
+	w.Header().Set("Content-Type", "application/xml")
+	_, _ = w.Write([]byte(body))
+}
+
+const testBucketName = "bazel-remote"
+
+func newTestBucket(t *testing.T, updateTimestamps bool) (*testBucket, cache.Proxy) {
+	t.Helper()
+
+	bucket := &testBucket{objects: make(map[string][]byte)}
+	bucket.srv = httptest.NewServer(http.HandlerFunc(bucket.handler))
+	t.Cleanup(bucket.srv.Close)
+
+	endpoint, err := url.Parse(bucket.srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := New(
+		endpoint.Host,
+		testBucketName,
+		minio.BucketLookupPath,
+		"",
+		credentials.New(&credentials.Static{}), // unsigned, so the body arrives unframed
+		true,                                   // DisableSSL, because httptest serves plain http
+		updateTimestamps,
+		"us-east-1", // set, so minio does not ask the bucket where it lives
+		1,
+		"zstd",
+		testutils.NewSilentLogger(),
+		testutils.NewSilentLogger(),
+		1, 10,
+	)
+
+	return bucket, proxy
+}
+
+// Uploads are queued and the caller is never told when one finishes, so wait for the bucket to stop
+// getting requests. Don't wait on a particular expected count, as the counts are what we want to assert.
+func (b *testBucket) awaitQuiet(t *testing.T) {
+	t.Helper()
+
+	settled := 0
+	for previous := -1; settled < 3; time.Sleep(50 * time.Millisecond) {
+		b.mu.Lock()
+		requests := b.requests
+		b.mu.Unlock()
+		if requests == previous {
+			settled++
+		} else {
+			settled = 0
+		}
+		previous = requests
+	}
+}
+
+func TestUploadSkipsExistingObject(t *testing.T) {
+	ctx := context.Background()
+	data, hash := testutils.RandomDataAndHash(256)
+
+	bucket, proxy := newTestBucket(t, false)
+
+	// A blob several actions produce is offered once per action. Only the first should be sent.
+	for range 3 {
+		proxy.Put(ctx, cache.CAS, hash, int64(len(data)), int64(len(data)),
+			io.NopCloser(bytes.NewReader(data)))
+	}
+	bucket.awaitQuiet(t)
+
+	bucket.mu.Lock()
+	defer bucket.mu.Unlock()
+	if bucket.puts != 1 {
+		t.Errorf("uploaded the same blob %d times, want 1", bucket.puts)
+	}
+	if bucket.heads != 3 {
+		t.Errorf("asked the bucket %d times whether it had the blob, want 3", bucket.heads)
+	}
+	if got := bucket.objects[objectKeyV2("", hash, cache.CAS)]; !bytes.Equal(got, data) {
+		t.Errorf("stored %d bytes under %s, want the %d offered", len(got), hash, len(data))
+	}
+}
+
+func TestUploadRefreshesSkippedObjectWithUpdateTimestamps(t *testing.T) {
+	ctx := context.Background()
+	data, hash := testutils.RandomDataAndHash(256)
+
+	bucket, proxy := newTestBucket(t, true)
+
+	proxy.Put(ctx, cache.CAS, hash, int64(len(data)), int64(len(data)),
+		io.NopCloser(bytes.NewReader(data)))
+	bucket.awaitQuiet(t)
+
+	// Skipping the upload still marks the object as refreshed
+	proxy.Put(ctx, cache.CAS, hash, int64(len(data)), int64(len(data)),
+		io.NopCloser(bytes.NewReader(data)))
+	bucket.awaitQuiet(t)
+
+	bucket.mu.Lock()
+	defer bucket.mu.Unlock()
+	if bucket.puts != 1 {
+		t.Errorf("uploaded the blob %d times, want 1", bucket.puts)
+	}
+	// With update_timestamps set, a skipped upload must still copy the object onto itself, which
+	// is how this backend renews an object's age for a lifecycle rule.
+	key := objectKeyV2("", hash, cache.CAS)
+	want := []objectCopy{{destination: key, source: testBucketName + "/" + key}}
+	if !slices.Equal(bucket.copies, want) {
+		t.Errorf("refreshed %v, want %v", bucket.copies, want)
 	}
 }


### PR DESCRIPTION
The http proxy backend HEADs an object before sending it and logs "SKIP UPLOAD" when it is already there. Do the same in the S3 backend. If the object already exists, only update its timestamp so that lifecycle rules don't evict it.

This avoids multiple uploads of blobs that several parallel actions produced and queued.

----

I tested this on a mid-sized project build: without the fix that did 278781 uploads for 60638 distinct objects, and sent 6.9 GB on the wire for 4.1 GB that got actually stored. This affects both S3 costs and also upoad time quite considerably. This is sort of the server-side counterpart to #919 (which is client-side) -- I'll look into that as well soon.

Thanks for considering!
